### PR TITLE
CI: Run Windows unit tests (Debug/Release x64/Win32)

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -63,7 +63,41 @@ jobs:
 
           Write-Host "Found test DLLs:"; $dlls | ForEach-Object { Write-Host " - $_" }
 
+          # Locate vstest.console.exe using vswhere, with fallbacks
+          $vstest = $null
+          $vswhere = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+          if (Test-Path $vswhere) {
+            $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.TestTools.Core -property installationPath 2>$null
+            if ($vsPath) {
+              $candidate = Join-Path $vsPath 'Common7\IDE\Extensions\TestPlatform\vstest.console.exe'
+              if (Test-Path $candidate) { $vstest = $candidate }
+            }
+          }
+
+          # Try common locations if vswhere didn't find vstest
+          if (-not $vstest) {
+            $fallbacks = @(
+              'C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\TestPlatform\vstest.console.exe',
+              'C:\Program Files (x86)\Microsoft Visual Studio\2022\Professional\Common7\IDE\Extensions\TestPlatform\vstest.console.exe',
+              'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\Extensions\TestPlatform\vstest.console.exe'
+            )
+            foreach ($f in $fallbacks) { if (Test-Path $f) { $vstest = $f; break } }
+          }
+
+          # Final fallback: search the PATH for vstest.console.exe or vstest
+          if (-not $vstest) {
+            $found = Get-Command vstest.console.exe -ErrorAction SilentlyContinue
+            if (-not $found) { $found = Get-Command vstest -ErrorAction SilentlyContinue }
+            if ($found) { $vstest = $found.Path }
+          }
+
+          if (-not $vstest) {
+            Write-Error "vstest.console.exe not found on runner. Aborting test run."; exit 1
+          }
+
+          Write-Host "Using vstest: $vstest"
           foreach ($dll in $dlls) {
             Write-Host "Running tests in $dll"
-            & "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\TestPlatform\vstest.console.exe" $dll /EnableCodeCoverage || exit $LASTEXITCODE
+            & $vstest $dll /EnableCodeCoverage
+            if ($LASTEXITCODE -ne 0) { Write-Error "Tests failed in $dll (exit $LASTEXITCODE)"; exit $LASTEXITCODE }
           }

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -67,10 +67,14 @@ jobs:
           $vstest = $null
           $vswhere = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
           if (Test-Path $vswhere) {
-            $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.TestTools.Core -property installationPath 2>$null
+            $vsPath = & $vswhere -latest -products * -property installationPath 2>$null
             if ($vsPath) {
               $candidate = Join-Path $vsPath 'Common7\IDE\Extensions\TestPlatform\vstest.console.exe'
               if (Test-Path $candidate) { $vstest = $candidate }
+              else {
+                $foundUnderVS = Get-ChildItem -Path $vsPath -Filter 'vstest.console.exe' -Recurse -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName -First 1
+                if ($foundUnderVS) { $vstest = $foundUnderVS }
+              }
             }
           }
 

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,0 +1,69 @@
+name: Run Unit Tests
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ ci/run-unit-tests ]
+
+jobs:
+  build-and-test:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        configuration: [ Debug, Release ]
+        platform: [ x64, Win32 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup MSBuild tools
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Install nuget
+        uses: nuget/setup-nuget@v1
+
+      - name: Restore NuGet packages
+        run: nuget restore "ctsTraffic.sln"
+
+      - name: Build solution
+        run: msbuild.exe "ctsTraffic.sln" /m /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }} /p:VisualStudioVersion=17.0
+
+      - name: Discover and run unit tests
+        shell: pwsh
+        run: |
+          Write-Host "Searching for test DLLs in the default output folders"
+          $config = "${{ matrix.configuration }}"
+          $platform = "${{ matrix.platform }}"
+          $searchPaths = @(
+            "$env:GITHUB_WORKSPACE\\x64\\$config",
+            "$env:GITHUB_WORKSPACE\\x86\\$config",
+            "$env:GITHUB_WORKSPACE\\bin\\$platform\\$config",
+            "$env:GITHUB_WORKSPACE\\bin\\$config",
+            "$env:GITHUB_WORKSPACE\\$platform\\$config",
+            "$env:GITHUB_WORKSPACE\\$platform\\$config"
+          )
+
+          $dlls = @()
+          foreach ($p in $searchPaths) {
+            if (Test-Path $p) {
+              $found = Get-ChildItem -Path $p -Filter '*UnitTest.dll' -Recurse -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName
+              $dlls += $found
+            }
+          }
+
+          if (-not $dlls) {
+            Write-Host "No test DLLs found in the typical output folders. Attempting full recursive search."
+            $dlls = Get-ChildItem -Path $env:GITHUB_WORKSPACE -Filter '*UnitTest.dll' -Recurse -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName
+          }
+
+          if (-not $dlls) {
+            Write-Host "No unit test DLLs found; job will succeed but no tests run."; exit 0
+          }
+
+          Write-Host "Found test DLLs:"; $dlls | ForEach-Object { Write-Host " - $_" }
+
+          foreach ($dll in $dlls) {
+            Write-Host "Running tests in $dll"
+            & "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\TestPlatform\vstest.console.exe" $dll /EnableCodeCoverage || exit $LASTEXITCODE
+          }


### PR DESCRIPTION
Adds a GitHub Actions workflow to build the solution and run all UnitTest DLLs on Windows for Debug and Release configurations and both x64 and Win32 platforms. This helps catch regressions in native tests on Windows CI.

Notes:
- The workflow searches for `*UnitTest.dll` under the repository output folders and runs them via `vstest.console.exe`.
- If you prefer fewer matrix entries (e.g., only x64), I can update the workflow accordingly.
