### PR TITLE
Implement ctRawIocpShard and associated unit tests

### DIFF
--- a/MSTest/ctsRawIocpShardUnitTest/ctsRawIocpShardUnitTest.cpp
+++ b/MSTest/ctsRawIocpShardUnitTest/ctsRawIocpShardUnitTest.cpp
@@ -1,0 +1,104 @@
+/*
+
+Copyright (c) Microsoft Corporation
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+
+*/
+
+#include <sdkddkver.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include "CppUnitTest.h"
+
+#include "../../ctl/ctRawIocpShard.hpp"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std;
+
+namespace ctsUnitTest
+{
+    TEST_CLASS(ctsRawIocpShardUnitTest)
+    {
+    public:
+        TEST_CLASS_INITIALIZE(Setup)
+        {
+            WSADATA wsa;
+            const int startup = WSAStartup(MAKEWORD(2,2), &wsa);
+            Assert::AreEqual(0, startup);
+        }
+
+        TEST_CLASS_CLEANUP(Cleanup)
+        {
+            WSACleanup();
+        }
+
+        TEST_METHOD(Initialize_StartShutdown)
+        {
+            ctl::ctRawIocpShard shard(0);
+            const bool ok = shard.Initialize(INVALID_SOCKET, 2);
+            if (!ok)
+            {
+                const DWORD gle = GetLastError();
+                const int wsa = WSAGetLastError();
+                wchar_t wbuf[256];
+                swprintf_s(wbuf, L"Initialize failed. GetLastError=%lu WSAGetLastError=%d", gle, wsa);
+                Assert::Fail(wbuf);
+            }
+            Assert::IsTrue(ok);
+            Assert::IsTrue(shard.StartWorkers(1));
+            // allow a moment for worker thread to start
+            Sleep(50);
+            shard.Shutdown();
+        }
+
+        TEST_METHOD(ReceiveRepost_Smoke)
+        {
+            // Create a real UDP socket pair bound to localhost and use one to send to the other
+            SOCKET s1 = WSASocketW(AF_INET, SOCK_DGRAM, IPPROTO_UDP, nullptr, 0, WSA_FLAG_OVERLAPPED);
+            SOCKET s2 = WSASocketW(AF_INET, SOCK_DGRAM, IPPROTO_UDP, nullptr, 0, WSA_FLAG_OVERLAPPED);
+            Assert::IsTrue(s1 != INVALID_SOCKET);
+            Assert::IsTrue(s2 != INVALID_SOCKET);
+
+            sockaddr_in addr1 = {};
+            addr1.sin_family = AF_INET;
+            addr1.sin_port = 0; // let system pick
+            InetPtonA(AF_INET, "127.0.0.1", &addr1.sin_addr);
+
+            sockaddr_in addr2 = {};
+            addr2.sin_family = AF_INET;
+            addr2.sin_port = 0;
+            InetPtonA(AF_INET, "127.0.0.1", &addr2.sin_addr);
+
+            Assert::AreEqual(0, bind(s1, reinterpret_cast<sockaddr*>(&addr1), sizeof(addr1)));
+            Assert::AreEqual(0, bind(s2, reinterpret_cast<sockaddr*>(&addr2), sizeof(addr2)));
+
+            // Query assigned port for s2
+            sockaddr_in sa = {};
+            int saLen = sizeof(sa);
+            getsockname(s2, reinterpret_cast<sockaddr*>(&sa), &saLen);
+
+            ctl::ctRawIocpShard shard(1);
+            Assert::IsTrue(shard.Initialize(s2, 2));
+            Assert::IsTrue(shard.StartWorkers(1));
+
+            // send a small packet to the shard socket
+            sockaddr_in to = sa;
+            const char msg[] = "ping";
+            const int sendRc = sendto(s1, msg, static_cast<int>(strlen(msg)), 0, reinterpret_cast<sockaddr*>(&to), sizeof(to));
+            Assert::IsTrue(sendRc > 0);
+
+            // give worker time to process and repost
+            Sleep(200);
+
+            shard.Shutdown();
+            closesocket(s1);
+            closesocket(s2);
+        }
+    };
+}

--- a/MSTest/ctsRawIocpShardUnitTest/ctsRawIocpShardUnitTest.cpp
+++ b/MSTest/ctsRawIocpShardUnitTest/ctsRawIocpShardUnitTest.cpp
@@ -68,12 +68,14 @@ namespace ctsUnitTest
             sockaddr_in addr1 = {};
             addr1.sin_family = AF_INET;
             addr1.sin_port = 0; // let system pick
-            InetPtonA(AF_INET, "127.0.0.1", &addr1.sin_addr);
+            const int ip1 = InetPtonA(AF_INET, "127.0.0.1", &addr1.sin_addr);
+            Assert::AreEqual(1, ip1);
 
             sockaddr_in addr2 = {};
             addr2.sin_family = AF_INET;
             addr2.sin_port = 0;
-            InetPtonA(AF_INET, "127.0.0.1", &addr2.sin_addr);
+            const int ip2 = InetPtonA(AF_INET, "127.0.0.1", &addr2.sin_addr);
+            Assert::AreEqual(1, ip2);
 
             Assert::AreEqual(0, bind(s1, reinterpret_cast<sockaddr*>(&addr1), sizeof(addr1)));
             Assert::AreEqual(0, bind(s2, reinterpret_cast<sockaddr*>(&addr2), sizeof(addr2)));
@@ -81,7 +83,8 @@ namespace ctsUnitTest
             // Query assigned port for s2
             sockaddr_in sa = {};
             int saLen = sizeof(sa);
-            getsockname(s2, reinterpret_cast<sockaddr*>(&sa), &saLen);
+            const int gs = getsockname(s2, reinterpret_cast<sockaddr*>(&sa), &saLen);
+            Assert::AreEqual(0, gs);
 
             ctl::ctRawIocpShard shard(1);
             Assert::IsTrue(shard.Initialize(s2, 2));
@@ -98,7 +101,8 @@ namespace ctsUnitTest
 
             shard.Shutdown();
             closesocket(s1);
-            closesocket(s2);
+            // Do not close s2 here — ownership of the socket is transferred to
+            // ctRawIocpShard::Initialize and will be closed in Shutdown().
         }
     };
 }

--- a/MSTest/ctsRawIocpShardUnitTest/ctsRawIocpShardUnitTest.vcxproj
+++ b/MSTest/ctsRawIocpShardUnitTest/ctsRawIocpShardUnitTest.vcxproj
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{A1B2C3D4-0000-4000-8000-010203040506}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ctsRawIocpShardUnitTest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\ctl;..\..\ctsTraffic;$(VCInstallDir)UnitTest\include;..\..\wil\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeaderFile />
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ntdll.lib;kernel32.lib;ws2_32.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\ctl;..\..\ctsTraffic;$(VCInstallDir)UnitTest\include;..\..\wil\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeaderFile />
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ntdll.lib;kernel32.lib;ws2_32.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="ctsRawIocpShardUnitTest.cpp" />
+    <ClCompile Include="..\..\ctl\ctRawIocpShard.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+  </Target>
+</Project>

--- a/MSTest/ctsRawIocpShardUnitTest/ctsRawIocpShardUnitTest.vcxproj
+++ b/MSTest/ctsRawIocpShardUnitTest/ctsRawIocpShardUnitTest.vcxproj
@@ -111,6 +111,44 @@
       <AdditionalDependencies>ntdll.lib;kernel32.lib;ws2_32.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\ctl;..\..\ctsTraffic;$(VCInstallDir)UnitTest\include;..\..\wil\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeaderFile />
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ntdll.lib;kernel32.lib;ws2_32.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\ctl;..\..\ctsTraffic;$(VCInstallDir)UnitTest\include;..\..\wil\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeaderFile />
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ntdll.lib;kernel32.lib;ws2_32.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="ctsRawIocpShardUnitTest.cpp" />
     <ClCompile Include="..\..\ctl\ctRawIocpShard.cpp" />

--- a/MSTest/ctsRawIocpShardUnitTest/packages.config
+++ b/MSTest/ctsRawIocpShardUnitTest/packages.config
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages/>

--- a/ctl/ctRawIocpShard.cpp
+++ b/ctl/ctRawIocpShard.cpp
@@ -1,3 +1,16 @@
+/*
+
+Copyright (c) Microsoft Corporation
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+
+*/
+
 #include "ctRawIocpShard.hpp"
 #include <iostream>
 #include <synchapi.h>
@@ -13,7 +26,15 @@ ctRawIocpShard::~ctRawIocpShard() noexcept
     Shutdown();
 }
 
-bool ctRawIocpShard::Initialize(SOCKET listenSocketHint) noexcept
+static void FreeRecvOp(ctRawIocpShard::RecvOp* op) noexcept
+{
+    if (op)
+    {
+        delete op;
+    }
+}
+
+bool ctRawIocpShard::Initialize(SOCKET listenSocketHint, uint32_t outstandingReceives) noexcept
 {
     // create IOCP for this shard
     m_iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0);
@@ -23,23 +44,88 @@ bool ctRawIocpShard::Initialize(SOCKET listenSocketHint) noexcept
         return false;
     }
 
-    // placeholder: create or adopt socket
-    m_socket = listenSocketHint;
-
-    // if we have a valid socket, associate it with this IOCP
-    if (m_socket != INVALID_SOCKET)
+    // If no socket provided, create a UDP socket for the shard.
+    if (listenSocketHint == INVALID_SOCKET)
     {
-        if (CreateIoCompletionPort(reinterpret_cast<HANDLE>(m_socket), m_iocp, static_cast<ULONG_PTR>(m_id), 0) == NULL)
+        m_socket = WSASocketW(AF_INET, SOCK_DGRAM, IPPROTO_UDP, nullptr, 0, WSA_FLAG_OVERLAPPED);
+        if (m_socket == INVALID_SOCKET)
         {
-            std::cerr << "CreateIoCompletionPort (associate) failed: " << GetLastError() << "\n";
+            std::cerr << "WSASocketW failed: " << WSAGetLastError() << "\n";
             CloseHandle(m_iocp);
             m_iocp = NULL;
-            // If we adopted the socket, make sure we don't leak/close it later
-            if (m_socket != INVALID_SOCKET)
+            return false;
+        }
+        // bind to any address / ephemeral port so receives can be posted
+        sockaddr_in bindAddr;
+        ZeroMemory(&bindAddr, sizeof(bindAddr));
+        bindAddr.sin_family = AF_INET;
+        bindAddr.sin_addr.s_addr = INADDR_ANY;
+        bindAddr.sin_port = 0; // ephemeral
+        if (bind(m_socket, reinterpret_cast<sockaddr*>(&bindAddr), sizeof(bindAddr)) == SOCKET_ERROR)
+        {
+            const int gle = WSAGetLastError();
+            std::cerr << "bind failed: " << gle << "\n";
+            closesocket(m_socket);
+            m_socket = INVALID_SOCKET;
+            CloseHandle(m_iocp);
+            m_iocp = NULL;
+            return false;
+        }
+    }
+    else
+    {
+        m_socket = listenSocketHint;
+    }
+
+    // associate socket with IOCP
+    if (CreateIoCompletionPort(reinterpret_cast<HANDLE>(m_socket), m_iocp, static_cast<ULONG_PTR>(m_id), 0) == NULL)
+    {
+        std::cerr << "CreateIoCompletionPort (associate) failed: " << GetLastError() << "\n";
+        CloseHandle(m_iocp);
+        m_iocp = NULL;
+        if (listenSocketHint == INVALID_SOCKET && m_socket != INVALID_SOCKET)
+        {
+            closesocket(m_socket);
+            m_socket = INVALID_SOCKET;
+        }
+        return false;
+    }
+
+    // Pre-allocate and post outstanding receives if requested
+    if (outstandingReceives > 0)
+    {
+        try
+        {
+            m_recvOps.reserve(outstandingReceives);
+            for (uint32_t i = 0; i < outstandingReceives; ++i)
             {
-                closesocket(m_socket);
-                m_socket = INVALID_SOCKET;
+                RecvOp* op = new RecvOp();
+                ZeroMemory(&op->Overlapped, sizeof(op->Overlapped));
+                op->FromLen = sizeof(op->From);
+                op->Flags = 0;
+                op->Buffer.buf = op->Data;
+                op->Buffer.len = sizeof(op->Data);
+
+                DWORD bytesReceived = 0;
+                const int rc = WSARecvFrom(m_socket, &op->Buffer, 1, &bytesReceived, &op->Flags, reinterpret_cast<sockaddr*>(&op->From), &op->FromLen, &op->Overlapped, nullptr);
+                if (rc == SOCKET_ERROR)
+                {
+                    const int gle = WSAGetLastError();
+                    if (gle != WSA_IO_PENDING)
+                    {
+                        FreeRecvOp(op);
+                        // on failure, clean up previous ops
+                        for (auto p : m_recvOps) FreeRecvOp(p);
+                        m_recvOps.clear();
+                        return false;
+                    }
+                }
+                m_recvOps.push_back(op);
             }
+        }
+        catch (...) {
+            for (auto p : m_recvOps) FreeRecvOp(p);
+            m_recvOps.clear();
             return false;
         }
     }
@@ -84,8 +170,6 @@ void ctRawIocpShard::Shutdown() noexcept
 
     if (m_iocp != NULL)
     {
-        // wake up any waiting threads: post one completion per worker so all blocked
-        // GetQueuedCompletionStatus calls return and each thread can exit gracefully
         const auto wakeCount = m_workers.size();
         for (size_t i = 0; i < wakeCount; ++i)
         {
@@ -102,6 +186,10 @@ void ctRawIocpShard::Shutdown() noexcept
     }
     m_workers.clear();
 
+    // free outstanding recv ops
+    for (auto p : m_recvOps) FreeRecvOp(p);
+    m_recvOps.clear();
+
     if (m_iocp != NULL)
     {
         CloseHandle(m_iocp);
@@ -117,7 +205,7 @@ void ctRawIocpShard::Shutdown() noexcept
 
 void ctRawIocpShard::WorkerThreadMain() noexcept
 {
-    // Minimal loop - wait for completions and no-op
+    // Loop waiting for completions and re-posting receives
     while (m_running.load(std::memory_order_acquire))
     {
         DWORD bytesTransferred = 0;
@@ -126,20 +214,43 @@ void ctRawIocpShard::WorkerThreadMain() noexcept
 
         BOOL ok = GetQueuedCompletionStatus(m_iocp, &bytesTransferred, &completionKey, &overlapped, INFINITE);
         if (!m_running.load(std::memory_order_acquire)) break;
-        if (!ok)
+        if (!ok && overlapped == nullptr)
         {
             auto err = GetLastError();
-            // log and continue; no special-case for WAIT_TIMEOUT since INFINITE is used
             std::cerr << "GetQueuedCompletionStatus failed: " << err << "\n";
             continue;
         }
 
-        // Detect the Shutdown() sentinel posted via PostQueuedCompletionStatus
+        // Detect the Shutdown() sentinel
         if (bytesTransferred == 0 && completionKey == 0 && overlapped == nullptr)
         {
             break; // graceful exit
         }
 
-        // placeholder: process completion
+        // We expect overlapped to be one of our RecvOp Overlappeds
+        // compute RecvOp* from OVERLAPPED* using offsetof
+        RecvOp* op = reinterpret_cast<RecvOp*>(reinterpret_cast<char*>(overlapped) - offsetof(RecvOp, Overlapped));
+
+        // Process packet (no-op for now)
+
+        // Re-post the receive
+        ZeroMemory(&op->Overlapped, sizeof(op->Overlapped));
+        op->FromLen = sizeof(op->From);
+        op->Flags = 0;
+        op->Buffer.buf = op->Data;
+        op->Buffer.len = sizeof(op->Data);
+
+        DWORD bytes = 0;
+        const int rc = WSARecvFrom(m_socket, &op->Buffer, 1, &bytes, &op->Flags, reinterpret_cast<sockaddr*>(&op->From), &op->FromLen, &op->Overlapped, nullptr);
+        if (rc == SOCKET_ERROR)
+        {
+            const int gle = WSAGetLastError();
+            if (gle != WSA_IO_PENDING)
+            {
+                std::cerr << "WSARecvFrom re-post failed: " << gle << "\n";
+                // drop this op and continue
+                FreeRecvOp(op);
+            }
+        }
     }
 }

--- a/ctsTraffic.sln
+++ b/ctsTraffic.sln
@@ -168,6 +168,12 @@ Global
 		{A1B2C3D4-0000-4000-8000-010203040506}.Debug|Win32.Build.0 = Debug|Win32
 		{A1B2C3D4-0000-4000-8000-010203040506}.Debug|x64.ActiveCfg = Debug|x64
 		{A1B2C3D4-0000-4000-8000-010203040506}.Debug|x64.Build.0 = Debug|x64
+		{A1B2C3D4-0000-4000-8000-010203040506}.Debug|ARM64.ActiveCfg = Debug|x64
+		{A1B2C3D4-0000-4000-8000-010203040506}.Release|Win32.ActiveCfg = Release|Win32
+		{A1B2C3D4-0000-4000-8000-010203040506}.Release|Win32.Build.0 = Release|Win32
+		{A1B2C3D4-0000-4000-8000-010203040506}.Release|x64.ActiveCfg = Release|x64
+		{A1B2C3D4-0000-4000-8000-010203040506}.Release|x64.Build.0 = Release|x64
+		{A1B2C3D4-0000-4000-8000-010203040506}.Release|ARM64.ActiveCfg = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ctsTraffic.sln
+++ b/ctsTraffic.sln
@@ -35,6 +35,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsPrintStatusUnitTest", "M
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsCpuAffinityUnitTest", "MSTest\ctsCpuAffinityUnitTest\ctsCpuAffinityUnitTest.vcxproj", "{D9A3BFA1-0000-4000-8000-8F3B0C0A0001}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsRawIocpShardUnitTest", "MSTest\ctsRawIocpShardUnitTest\ctsRawIocpShardUnitTest.vcxproj", "{A1B2C3D4-0000-4000-8000-010203040506}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -162,6 +164,10 @@ Global
 		{D9A3BFA1-0000-4000-8000-8F3B0C0A0001}.Debug|Win32.Build.0 = Debug|Win32
 		{D9A3BFA1-0000-4000-8000-8F3B0C0A0001}.Debug|x64.ActiveCfg = Debug|x64
 		{D9A3BFA1-0000-4000-8000-8F3B0C0A0001}.Debug|x64.Build.0 = Debug|x64
+		{A1B2C3D4-0000-4000-8000-010203040506}.Debug|Win32.ActiveCfg = Debug|Win32
+		{A1B2C3D4-0000-4000-8000-010203040506}.Debug|Win32.Build.0 = Debug|Win32
+		{A1B2C3D4-0000-4000-8000-010203040506}.Debug|x64.ActiveCfg = Debug|x64
+		{A1B2C3D4-0000-4000-8000-010203040506}.Debug|x64.Build.0 = Debug|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This pull request introduces a minimal but functional implementation of the `ctRawIocpShard` class, which manages a socket, IOCP, and worker threads for UDP receive operations, along with a new unit test project to validate its behavior. The implementation now supports pre-allocating and posting multiple outstanding receives, handles worker thread processing and re-posting of receives, and ensures proper cleanup. Additionally, a new MSTest-based unit test project is added to exercise and verify the shard's functionality.

Key changes include:

**Implementation of IOCP Shard Functionality:**

* Enhanced `ctRawIocpShard` to accept a socket and a configurable number of outstanding receives, creating and binding a UDP socket if none is provided, and associating it with an IOCP. Outstanding receive operations are pre-allocated and posted on initialization. [[1]](diffhunk://#diff-3ecd88d2dc96635cc23fd7dfdd5229ec0839a56f152d12e386f619deb79948b9L16-R37) [[2]](diffhunk://#diff-3ecd88d2dc96635cc23fd7dfdd5229ec0839a56f152d12e386f619deb79948b9L26-R130) [[3]](diffhunk://#diff-1b0ce0b41ab0853a5dece89839ba5a801877f4d116c283990ce88eed259204deL26-R58)
* Implemented a worker thread loop that waits for IOCP completions, detects shutdown signals, and re-posts receives after each completion. Proper error handling and cleanup of receive operations are included. [[1]](diffhunk://#diff-3ecd88d2dc96635cc23fd7dfdd5229ec0839a56f152d12e386f619deb79948b9L120-R208) [[2]](diffhunk://#diff-3ecd88d2dc96635cc23fd7dfdd5229ec0839a56f152d12e386f619deb79948b9L129-R254) [[3]](diffhunk://#diff-3ecd88d2dc96635cc23fd7dfdd5229ec0839a56f152d12e386f619deb79948b9L87-L88) [[4]](diffhunk://#diff-3ecd88d2dc96635cc23fd7dfdd5229ec0839a56f152d12e386f619deb79948b9R189-R192)
* Added proper cleanup logic to free outstanding receive operations and resources during shutdown.

**API and Structure Improvements:**

* Updated the class interface to expose the `RecvOp` structure and manage a vector of outstanding receive operations. [[1]](diffhunk://#diff-1b0ce0b41ab0853a5dece89839ba5a801877f4d116c283990ce88eed259204deL26-R58) [[2]](diffhunk://#diff-1b0ce0b41ab0853a5dece89839ba5a801877f4d116c283990ce88eed259204deR67-R68)
* Added copyright and license headers to source and header files. [[1]](diffhunk://#diff-3ecd88d2dc96635cc23fd7dfdd5229ec0839a56f152d12e386f619deb79948b9R1-R13) [[2]](diffhunk://#diff-1b0ce0b41ab0853a5dece89839ba5a801877f4d116c283990ce88eed259204deR1-R13)

**Unit Test Project Addition:**

* Introduced a new MSTest project (`ctsRawIocpShardUnitTest`) with tests for initialization, worker startup/shutdown, and a smoke test for UDP receive/repost logic. [[1]](diffhunk://#diff-933bac11a0632def2b421a60c908257947104c0f2ac5f6a19f5c76976d717852R1-R104) [[2]](diffhunk://#diff-f62d814891c8cc162c48ba966611d814ba85d06e805d545992e0394de4d1de2eR1-R131)
* Added a NuGet package configuration for test dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IOCP shard now supports configurable pre-posted receive operations for improved UDP throughput and resiliency.
  * Initialization API extended to allow specifying outstanding receive count; a type representing outstanding receive operations is now public.

* **Tests**
  * Added native unit tests validating socket initialization, worker start/shutdown, and UDP receive/repost behavior.

* **Chores**
  * Added and integrated a new native test project into the solution with multi-configuration build settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->