### PR TITLE
Media upload

### DIFF
--- a/MSTest/ctsMediaUploadClientUnitTest/ctsMediaUploadClientUnitTest.cpp
+++ b/MSTest/ctsMediaUploadClientUnitTest/ctsMediaUploadClientUnitTest.cpp
@@ -1,0 +1,35 @@
+// Unit tests for ctsMediaUpload protocol helpers (client-side behaviors)
+#include <sdkddkver.h>
+#include "CppUnitTest.h"
+
+#include "ctsMediaUploadProtocol.hpp"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace ctsTraffic;
+
+namespace ctsUnitTest
+{
+    TEST_CLASS(ctsMediaUploadClientUnitTest)
+    {
+    public:
+        TEST_METHOD(Extract_StartMessage)
+        {
+            const char start[] = "START";
+            auto msg = ctsMediaUploadMessage::Extract(start, static_cast<uint32_t>(sizeof(start) - 1));
+            Assert::IsTrue(msg.m_action == MediaUploadAction::START);
+        }
+
+        TEST_METHOD(Extract_InvalidThrows)
+        {
+            const char bad[] = "BAD";
+            bool threw = false;
+            try
+            {
+                (void)ctsMediaUploadMessage::Extract(bad, static_cast<uint32_t>(sizeof(bad) - 1));
+            }
+            catch (...) { threw = true; }
+
+            Assert::IsTrue(threw);
+        }
+    };
+}

--- a/MSTest/ctsMediaUploadClientUnitTest/ctsMediaUploadClientUnitTest.vcxproj
+++ b/MSTest/ctsMediaUploadClientUnitTest/ctsMediaUploadClientUnitTest.vcxproj
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0004}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ctsMediaUploadClientUnitTest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)\ctl;$(SolutionDir)\ctsTraffic;$(VCInstallDir)UnitTest\include;..\..\wil\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <AdditionalOptions>/D "_MSVC_STL_HARDENING=1" /D "_MSVC_STL_DESTRUCTOR_TOMBSTONES=1" /D "_WIN32_WINNT=_WIN32_WINNT_WIN7" /D "_WINSOCK_DEPRECATED_NO_WARNINGS" /D "NOMINMAX"</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ntdll.lib;kernel32.lib;ws2_32.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="ctsMediaUploadClientUnitTest.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+  </Target>
+</Project>

--- a/MSTest/ctsMediaUploadClientUnitTest/ctsMediaUploadClientUnitTest.vcxproj
+++ b/MSTest/ctsMediaUploadClientUnitTest/ctsMediaUploadClientUnitTest.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0004}</ProjectGuid>
+    <ProjectGuid>{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ctsMediaUploadClientUnitTest</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>

--- a/MSTest/ctsMediaUploadServerConnectedSocketUnitTest/ctsMediaUploadServerConnectedSocketUnitTest.cpp
+++ b/MSTest/ctsMediaUploadServerConnectedSocketUnitTest/ctsMediaUploadServerConnectedSocketUnitTest.cpp
@@ -1,0 +1,58 @@
+// Unit tests for ctsMediaUpload server connected socket helpers
+#include <sdkddkver.h>
+#include "CppUnitTest.h"
+
+#include "ctsMediaUploadProtocol.hpp"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace ctsTraffic;
+
+// Minimal stubs for ctsConfig functions referenced by the protocol helpers
+namespace ctsConfigStub {
+    void PrintErrorInfo(PCWSTR, ...) noexcept {}
+    const ctsConfig::MediaStreamSettings& GetMediaStreamStub() noexcept
+    {
+        static ctsConfig::MediaStreamSettings s;
+        if (s.DatagramMaxSize == 0) {
+            s.DatagramMaxSize = 1500;
+            s.BitsPerSecond = 8000000;
+            s.FramesPerSecond = 30;
+            s.BufferDepthSeconds = 1;
+            s.StreamLengthSeconds = 1;
+        }
+        return s;
+    }
+}
+
+// Linker-friendly redirectors placed in the ctsTraffic::ctsConfig namespace
+namespace ctsTraffic { namespace ctsConfig {
+    void PrintErrorInfo(PCWSTR text, ...) noexcept { ctsConfigStub::PrintErrorInfo(text); }
+    const MediaStreamSettings& GetMediaStream() noexcept { return ctsConfigStub::GetMediaStreamStub(); }
+} }
+
+namespace ctsUnitTest
+{
+    TEST_CLASS(ctsMediaUploadServerConnectedSocketUnitTest)
+    {
+    public:
+        TEST_METHOD(ValidateBufferLengthFromTask_DataAndId)
+        {
+            ctsTask task{};
+            // test Data frame: protocol header + seq + qpc + qpf + at least 1 byte
+            task.m_buffer = (char*)malloc(c_udpDatagramDataHeaderLength + 1);
+            task.m_bufferLength = c_udpDatagramDataHeaderLength + 1;
+            // set protocol header to DATA
+            *reinterpret_cast<unsigned short*>(task.m_buffer) = c_udpDatagramProtocolHeaderFlagData;
+            Assert::IsTrue(ctsMediaUploadMessage::ValidateBufferLengthFromTask(task, task.m_bufferLength));
+            free(task.m_buffer);
+
+            // test ID frame: header + connection id length
+            ctsTask idTask{};
+            idTask.m_bufferLength = c_udpDatagramProtocolHeaderFlagLength + ctsStatistics::ConnectionIdLength;
+            idTask.m_buffer = (char*)malloc(idTask.m_bufferLength);
+            *reinterpret_cast<unsigned short*>(idTask.m_buffer) = c_udpDatagramProtocolHeaderFlagId;
+            Assert::IsTrue(ctsMediaUploadMessage::ValidateBufferLengthFromTask(idTask, idTask.m_bufferLength));
+            free(idTask.m_buffer);
+        }
+    };
+}

--- a/MSTest/ctsMediaUploadServerConnectedSocketUnitTest/ctsMediaUploadServerConnectedSocketUnitTest.vcxproj
+++ b/MSTest/ctsMediaUploadServerConnectedSocketUnitTest/ctsMediaUploadServerConnectedSocketUnitTest.vcxproj
@@ -35,7 +35,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0001}</ProjectGuid>
+    <ProjectGuid>{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ctsMediaUploadServerConnectedSocketUnitTest</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>

--- a/MSTest/ctsMediaUploadServerConnectedSocketUnitTest/ctsMediaUploadServerConnectedSocketUnitTest.vcxproj
+++ b/MSTest/ctsMediaUploadServerConnectedSocketUnitTest/ctsMediaUploadServerConnectedSocketUnitTest.vcxproj
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0001}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ctsMediaUploadServerConnectedSocketUnitTest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)\ctl;$(SolutionDir)\ctsTraffic;$(VCInstallDir)UnitTest\include;..\..\wil\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <AdditionalOptions>/D "_MSVC_STL_HARDENING=1" /D "_MSVC_STL_DESTRUCTOR_TOMBSTONES=1" /D "_WIN32_WINNT=_WIN32_WINNT_WIN7" /D "_WINSOCK_DEPRECATED_NO_WARNINGS" /D "NOMINMAX"</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ntdll.lib;kernel32.lib;ws2_32.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="ctsMediaUploadServerConnectedSocketUnitTest.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  </ImportGroup>
+</Project>

--- a/MSTest/ctsMediaUploadServerListeningSocketUnitTest/ctsMediaUploadServerListeningSocketUnitTest.cpp
+++ b/MSTest/ctsMediaUploadServerListeningSocketUnitTest/ctsMediaUploadServerListeningSocketUnitTest.cpp
@@ -1,0 +1,35 @@
+// Unit tests for ctsMediaUpload protocol helpers used by server listening socket
+#include <sdkddkver.h>
+#include "CppUnitTest.h"
+
+#include "ctsMediaUploadProtocol.hpp"
+#include "ctsIOTask.hpp"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace ctsTraffic;
+
+namespace ctsUnitTest
+{
+    TEST_CLASS(ctsMediaUploadServerListeningSocketUnitTest)
+    {
+    public:
+        TEST_METHOD(Construct_StartTask)
+        {
+            auto task = ctsMediaUploadMessage::Construct(MediaUploadAction::START);
+            Assert::IsTrue(task.m_ioAction == ctsTaskAction::Send);
+            Assert::IsTrue(task.m_bufferLength == c_udpDatagramStartStringLength);
+        }
+
+        TEST_METHOD(MakeConnectionIdTask_Length)
+        {
+            ctsTask raw{};
+            raw.m_bufferLength = ctsStatistics::ConnectionIdLength + c_udpDatagramProtocolHeaderFlagLength;
+            raw.m_buffer = (char*)malloc(raw.m_bufferLength);
+            // provide a fake connection id
+            const char conn[ctsStatistics::ConnectionIdLength] = "00000000-0000-0000-0000-000000000000";
+            auto out = ctsMediaUploadMessage::MakeConnectionIdTask(raw, conn);
+            Assert::AreEqual(out.m_bufferLength, raw.m_bufferLength);
+            free(raw.m_buffer);
+        }
+    };
+}

--- a/MSTest/ctsMediaUploadServerListeningSocketUnitTest/ctsMediaUploadServerListeningSocketUnitTest.vcxproj
+++ b/MSTest/ctsMediaUploadServerListeningSocketUnitTest/ctsMediaUploadServerListeningSocketUnitTest.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0002}</ProjectGuid>
+    <ProjectGuid>{C106A864-1897-4D38-818A-48C2D6152B60}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ctsMediaUploadServerListeningSocketUnitTest</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>

--- a/MSTest/ctsMediaUploadServerListeningSocketUnitTest/ctsMediaUploadServerListeningSocketUnitTest.vcxproj
+++ b/MSTest/ctsMediaUploadServerListeningSocketUnitTest/ctsMediaUploadServerListeningSocketUnitTest.vcxproj
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0002}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ctsMediaUploadServerListeningSocketUnitTest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)\ctl;$(SolutionDir)\ctsTraffic;$(VCInstallDir)UnitTest\include;..\..\wil\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <AdditionalOptions>/D "_MSVC_STL_HARDENING=1" /D "_MSVC_STL_DESTRUCTOR_TOMBSTONES=1" /D "_WIN32_WINNT=_WIN32_WINNT_WIN7" /D "_WINSOCK_DEPRECATED_NO_WARNINGS" /D "NOMINMAX"</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ntdll.lib;kernel32.lib;ws2_32.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="ctsMediaUploadServerListeningSocketUnitTest.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+  </Target>
+</Project>

--- a/MSTest/ctsMediaUploadServerUnitTest/ctsMediaUploadServerUnitTest.cpp
+++ b/MSTest/ctsMediaUploadServerUnitTest/ctsMediaUploadServerUnitTest.cpp
@@ -1,0 +1,29 @@
+// Unit tests for server-side media upload helpers
+#include <sdkddkver.h>
+#include "CppUnitTest.h"
+
+#include "ctsMediaUploadProtocol.hpp"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace ctsTraffic;
+
+namespace ctsUnitTest
+{
+    TEST_CLASS(ctsMediaUploadServerUnitTest)
+    {
+    public:
+        TEST_METHOD(MakeConnectionIdTask_ContainsHeader)
+        {
+            ctsTask raw{};
+            raw.m_bufferLength = ctsStatistics::ConnectionIdLength + c_udpDatagramProtocolHeaderFlagLength;
+            raw.m_buffer = (char*)malloc(raw.m_bufferLength);
+
+            const char conn[ctsStatistics::ConnectionIdLength] = "11111111-1111-1111-1111-111111111111";
+            auto task = ctsMediaUploadMessage::MakeConnectionIdTask(raw, conn);
+            // the protocol header should be set to the Id flag in the returned task buffer
+            unsigned short hdr = *reinterpret_cast<unsigned short*>(task.m_buffer);
+            Assert::AreEqual(static_cast<unsigned short>(c_udpDatagramProtocolHeaderFlagId), hdr);
+            free(raw.m_buffer);
+        }
+    };
+}

--- a/MSTest/ctsMediaUploadServerUnitTest/ctsMediaUploadServerUnitTest.vcxproj
+++ b/MSTest/ctsMediaUploadServerUnitTest/ctsMediaUploadServerUnitTest.vcxproj
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0003}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ctsMediaUploadServerUnitTest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)\ctl;$(SolutionDir)\ctsTraffic;$(VCInstallDir)UnitTest\include;..\..\wil\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <AdditionalOptions>/D "_MSVC_STL_HARDENING=1" /D "_MSVC_STL_DESTRUCTOR_TOMBSTONES=1" /D "_WIN32_WINNT=_WIN32_WINNT_WIN7" /D "_WINSOCK_DEPRECATED_NO_WARNINGS" /D "NOMINMAX"</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ntdll.lib;kernel32.lib;ws2_32.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="ctsMediaUploadServerUnitTest.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+  </Target>
+</Project>

--- a/MSTest/ctsMediaUploadServerUnitTest/ctsMediaUploadServerUnitTest.vcxproj
+++ b/MSTest/ctsMediaUploadServerUnitTest/ctsMediaUploadServerUnitTest.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0003}</ProjectGuid>
+    <ProjectGuid>{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ctsMediaUploadServerUnitTest</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>

--- a/TestResults/alanjo_ALANJO-LAPTOP_2025-11-26_17_29_15.trx
+++ b/TestResults/alanjo_ALANJO-LAPTOP_2025-11-26_17_29_15.trx
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TestRun id="1a997e8b-5fe1-484d-a1a8-d425b1edfd96" name="alanjo@ALANJO-LAPTOP 2025-11-26 17:29:15" runUser="REDMOND\alanjo" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <Times creation="2025-11-26T17:29:15.9808528-08:00" queuing="2025-11-26T17:29:15.9808528-08:00" start="2025-11-26T17:29:14.1437122-08:00" finish="2025-11-26T17:29:16.0031453-08:00" />
+  <TestSettings name="default" id="aff3d645-b725-4770-bf4d-42476d939ce7">
+    <Deployment runDeploymentRoot="alanjo_ALANJO-LAPTOP_2025-11-26_17_29_15" />
+  </TestSettings>
+  <Results>
+    <UnitTestResult executionId="7e9ea517-618e-4dc4-8732-113030faf36a" testId="f0963a51-a8d5-99e3-a339-c8328bc6c546" testName="Extract_StartMessage" computerName="ALANJO-LAPTOP" duration="00:00:00.0000085" startTime="2025-11-26T17:29:15.7993884-08:00" endTime="2025-11-26T17:29:15.7993969-08:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="7e9ea517-618e-4dc4-8732-113030faf36a" />
+    <UnitTestResult executionId="4ad50ffd-1679-4a69-8484-6104466816ef" testId="341634ea-9367-f02f-d92e-50791d8f71e4" testName="Extract_InvalidThrows" computerName="ALANJO-LAPTOP" duration="00:00:00.0019910" startTime="2025-11-26T17:29:15.8106417-08:00" endTime="2025-11-26T17:29:15.8126327-08:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4ad50ffd-1679-4a69-8484-6104466816ef" />
+    <UnitTestResult executionId="c8222f78-7e50-4d7b-b579-c642e98fd483" testId="9ed3ab75-3475-7bd3-0fe2-5d207b3e370c" testName="MakeConnectionIdTask_ContainsHeader" computerName="ALANJO-LAPTOP" duration="00:00:00.0000616" startTime="2025-11-26T17:29:15.8174070-08:00" endTime="2025-11-26T17:29:15.8174686-08:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c8222f78-7e50-4d7b-b579-c642e98fd483" />
+    <UnitTestResult executionId="efce4e6a-87f2-4b1b-9a63-763e74c1cfd4" testId="74833903-ddf5-ea2e-a98d-da635115f71f" testName="ValidateBufferLengthFromTask_DataAndId" computerName="ALANJO-LAPTOP" duration="00:00:00.0000083" startTime="2025-11-26T17:29:15.8174070-08:00" endTime="2025-11-26T17:29:15.8174153-08:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="efce4e6a-87f2-4b1b-9a63-763e74c1cfd4" />
+    <UnitTestResult executionId="05414ef0-cd39-4967-8cdf-d19a6f2f355d" testId="63f5c938-b3cf-9100-eae3-9493d09d3307" testName="MakeConnectionIdTask_Length" computerName="ALANJO-LAPTOP" duration="00:00:00.0001710" startTime="2025-11-26T17:29:15.8135566-08:00" endTime="2025-11-26T17:29:15.8137276-08:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="05414ef0-cd39-4967-8cdf-d19a6f2f355d" />
+    <UnitTestResult executionId="a9d6ff46-945b-4d98-afcc-166449e0b48b" testId="e810bbc0-846f-a816-b54f-a48585574d25" testName="Construct_StartTask" computerName="ALANJO-LAPTOP" duration="00:00:00.0000056" startTime="2025-11-26T17:29:15.8135566-08:00" endTime="2025-11-26T17:29:15.8135622-08:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a9d6ff46-945b-4d98-afcc-166449e0b48b" />
+  </Results>
+  <TestDefinitions>
+    <UnitTest name="ValidateBufferLengthFromTask_DataAndId" storage="f:\ctstraffic\x64\debug\ctsmediauploadserverconnectedsocketunittest.dll" id="74833903-ddf5-ea2e-a98d-da635115f71f">
+      <Execution id="efce4e6a-87f2-4b1b-9a63-763e74c1cfd4" />
+      <TestMethod codeBase="f:\ctsTraffic\x64\Debug\ctsMediaUploadServerConnectedSocketUnitTest.dll" adapterTypeName="executor://cppunittestexecutor/v1" className="ctsUnitTest.ctsMediaUploadServerConnectedSocketUnitTest" name="ctsUnitTest::ctsMediaUploadServerConnectedSocketUnitTest::ValidateBufferLengthFromTask_DataAndId" />
+    </UnitTest>
+    <UnitTest name="Construct_StartTask" storage="f:\ctstraffic\x64\debug\ctsmediauploadserverlisteningsocketunittest.dll" id="e810bbc0-846f-a816-b54f-a48585574d25">
+      <Execution id="a9d6ff46-945b-4d98-afcc-166449e0b48b" />
+      <TestMethod codeBase="f:\ctsTraffic\x64\Debug\ctsMediaUploadServerListeningSocketUnitTest.dll" adapterTypeName="executor://cppunittestexecutor/v1" className="ctsUnitTest.ctsMediaUploadServerListeningSocketUnitTest" name="ctsUnitTest::ctsMediaUploadServerListeningSocketUnitTest::Construct_StartTask" />
+    </UnitTest>
+    <UnitTest name="MakeConnectionIdTask_ContainsHeader" storage="f:\ctstraffic\x64\debug\ctsmediauploadserverunittest.dll" id="9ed3ab75-3475-7bd3-0fe2-5d207b3e370c">
+      <Execution id="c8222f78-7e50-4d7b-b579-c642e98fd483" />
+      <TestMethod codeBase="f:\ctsTraffic\x64\Debug\ctsMediaUploadServerUnitTest.dll" adapterTypeName="executor://cppunittestexecutor/v1" className="ctsUnitTest.ctsMediaUploadServerUnitTest" name="ctsUnitTest::ctsMediaUploadServerUnitTest::MakeConnectionIdTask_ContainsHeader" />
+    </UnitTest>
+    <UnitTest name="Extract_InvalidThrows" storage="f:\ctstraffic\x64\debug\ctsmediauploadclientunittest.dll" id="341634ea-9367-f02f-d92e-50791d8f71e4">
+      <Execution id="4ad50ffd-1679-4a69-8484-6104466816ef" />
+      <TestMethod codeBase="f:\ctsTraffic\x64\Debug\ctsMediaUploadClientUnitTest.dll" adapterTypeName="executor://cppunittestexecutor/v1" className="ctsUnitTest.ctsMediaUploadClientUnitTest" name="ctsUnitTest::ctsMediaUploadClientUnitTest::Extract_InvalidThrows" />
+    </UnitTest>
+    <UnitTest name="Extract_StartMessage" storage="f:\ctstraffic\x64\debug\ctsmediauploadclientunittest.dll" id="f0963a51-a8d5-99e3-a339-c8328bc6c546">
+      <Execution id="7e9ea517-618e-4dc4-8732-113030faf36a" />
+      <TestMethod codeBase="f:\ctsTraffic\x64\Debug\ctsMediaUploadClientUnitTest.dll" adapterTypeName="executor://cppunittestexecutor/v1" className="ctsUnitTest.ctsMediaUploadClientUnitTest" name="ctsUnitTest::ctsMediaUploadClientUnitTest::Extract_StartMessage" />
+    </UnitTest>
+    <UnitTest name="MakeConnectionIdTask_Length" storage="f:\ctstraffic\x64\debug\ctsmediauploadserverlisteningsocketunittest.dll" id="63f5c938-b3cf-9100-eae3-9493d09d3307">
+      <Execution id="05414ef0-cd39-4967-8cdf-d19a6f2f355d" />
+      <TestMethod codeBase="f:\ctsTraffic\x64\Debug\ctsMediaUploadServerListeningSocketUnitTest.dll" adapterTypeName="executor://cppunittestexecutor/v1" className="ctsUnitTest.ctsMediaUploadServerListeningSocketUnitTest" name="ctsUnitTest::ctsMediaUploadServerListeningSocketUnitTest::MakeConnectionIdTask_Length" />
+    </UnitTest>
+  </TestDefinitions>
+  <TestEntries>
+    <TestEntry testId="f0963a51-a8d5-99e3-a339-c8328bc6c546" executionId="7e9ea517-618e-4dc4-8732-113030faf36a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="341634ea-9367-f02f-d92e-50791d8f71e4" executionId="4ad50ffd-1679-4a69-8484-6104466816ef" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9ed3ab75-3475-7bd3-0fe2-5d207b3e370c" executionId="c8222f78-7e50-4d7b-b579-c642e98fd483" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="74833903-ddf5-ea2e-a98d-da635115f71f" executionId="efce4e6a-87f2-4b1b-9a63-763e74c1cfd4" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="63f5c938-b3cf-9100-eae3-9493d09d3307" executionId="05414ef0-cd39-4967-8cdf-d19a6f2f355d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e810bbc0-846f-a816-b54f-a48585574d25" executionId="a9d6ff46-945b-4d98-afcc-166449e0b48b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+  </TestEntries>
+  <TestLists>
+    <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
+  </TestLists>
+  <ResultSummary outcome="Completed">
+    <Counters total="6" executed="6" passed="6" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    <RunInfos>
+      <RunInfo computerName="ALANJO-LAPTOP" outcome="Warning" timestamp="2025-11-26T17:29:15.0595896-08:00">
+        <Text>Data collection : Unable to find a datacollector with friendly name 'Code Coverage'.</Text>
+      </RunInfo>
+      <RunInfo computerName="ALANJO-LAPTOP" outcome="Warning" timestamp="2025-11-26T17:29:15.0634561-08:00">
+        <Text>Data collection : Could not find data collector 'Code Coverage'</Text>
+      </RunInfo>
+    </RunInfos>
+  </ResultSummary>
+</TestRun>

--- a/ctsTraffic.sln
+++ b/ctsTraffic.sln
@@ -27,13 +27,13 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsIOPatternRateLimitPolicy
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaStreamServerConnectedSocketUnitTest", "MSTest\ctsMediaStreamServerConnectedSocketUnitTest\ctsMediaStreamServerConnectedSocketUnitTest.vcxproj", "{47AB4470-4617-47FA-9529-3A1D1DA7FAA0}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaUploadServerConnectedSocketUnitTest", "MSTest\ctsMediaUploadServerConnectedSocketUnitTest\ctsMediaUploadServerConnectedSocketUnitTest.vcxproj", "{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0001}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaUploadServerConnectedSocketUnitTest", "MSTest\ctsMediaUploadServerConnectedSocketUnitTest\ctsMediaUploadServerConnectedSocketUnitTest.vcxproj", "{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaUploadServerListeningSocketUnitTest", "MSTest\ctsMediaUploadServerListeningSocketUnitTest\ctsMediaUploadServerListeningSocketUnitTest.vcxproj", "{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0002}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaUploadServerListeningSocketUnitTest", "MSTest\ctsMediaUploadServerListeningSocketUnitTest\ctsMediaUploadServerListeningSocketUnitTest.vcxproj", "{C106A864-1897-4D38-818A-48C2D6152B60}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaUploadServerUnitTest", "MSTest\ctsMediaUploadServerUnitTest\ctsMediaUploadServerUnitTest.vcxproj", "{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0003}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaUploadServerUnitTest", "MSTest\ctsMediaUploadServerUnitTest\ctsMediaUploadServerUnitTest.vcxproj", "{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaUploadClientUnitTest", "MSTest\ctsMediaUploadClientUnitTest\ctsMediaUploadClientUnitTest.vcxproj", "{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0004}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaUploadClientUnitTest", "MSTest\ctsMediaUploadClientUnitTest\ctsMediaUploadClientUnitTest.vcxproj", "{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UnitTests", "UnitTests", "{F6BA338C-59FD-4354-9F13-1B5511486DC9}"
 EndProject
@@ -144,18 +144,54 @@ Global
 		{47AB4470-4617-47FA-9529-3A1D1DA7FAA0}.Release|ARM64.ActiveCfg = Release|ARM64
 		{47AB4470-4617-47FA-9529-3A1D1DA7FAA0}.Release|Win32.ActiveCfg = Release|Win32
 		{47AB4470-4617-47FA-9529-3A1D1DA7FAA0}.Release|x64.ActiveCfg = Release|x64
-		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0001}.Debug|x64.ActiveCfg = Debug|x64
-		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0001}.Debug|x64.Build.0 = Debug|x64
-		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0001}.Release|x64.ActiveCfg = Release|x64
-		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0002}.Debug|x64.ActiveCfg = Debug|x64
-		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0002}.Debug|x64.Build.0 = Debug|x64
-		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0002}.Release|x64.ActiveCfg = Release|x64
-		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0003}.Debug|x64.ActiveCfg = Debug|x64
-		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0003}.Debug|x64.Build.0 = Debug|x64
-		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0003}.Release|x64.ActiveCfg = Release|x64
-		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0004}.Debug|x64.ActiveCfg = Debug|x64
-		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0004}.Debug|x64.Build.0 = Debug|x64
-		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0004}.Release|x64.ActiveCfg = Release|x64
+		{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}.Debug|ARM64.Build.0 = Debug|ARM64
+		{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}.Debug|Win32.ActiveCfg = Debug|Win32
+		{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}.Debug|Win32.Build.0 = Debug|Win32
+		{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}.Debug|x64.ActiveCfg = Debug|x64
+		{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}.Debug|x64.Build.0 = Debug|x64
+		{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}.Release|ARM64.ActiveCfg = Release|ARM64
+		{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}.Release|ARM64.Build.0 = Release|ARM64
+		{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}.Release|Win32.ActiveCfg = Release|Win32
+		{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}.Release|Win32.Build.0 = Release|Win32
+		{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}.Release|x64.ActiveCfg = Release|x64
+		{16A9B8D2-BCF4-4E2B-8207-E459004C9E0A}.Release|x64.Build.0 = Release|x64
+		{C106A864-1897-4D38-818A-48C2D6152B60}.Debug|ARM64.ActiveCfg = Debug|x64
+		{C106A864-1897-4D38-818A-48C2D6152B60}.Debug|ARM64.Build.0 = Debug|x64
+		{C106A864-1897-4D38-818A-48C2D6152B60}.Debug|Win32.ActiveCfg = Debug|x64
+		{C106A864-1897-4D38-818A-48C2D6152B60}.Debug|Win32.Build.0 = Debug|x64
+		{C106A864-1897-4D38-818A-48C2D6152B60}.Debug|x64.ActiveCfg = Debug|x64
+		{C106A864-1897-4D38-818A-48C2D6152B60}.Debug|x64.Build.0 = Debug|x64
+		{C106A864-1897-4D38-818A-48C2D6152B60}.Release|ARM64.ActiveCfg = Release|x64
+		{C106A864-1897-4D38-818A-48C2D6152B60}.Release|ARM64.Build.0 = Release|x64
+		{C106A864-1897-4D38-818A-48C2D6152B60}.Release|Win32.ActiveCfg = Release|x64
+		{C106A864-1897-4D38-818A-48C2D6152B60}.Release|Win32.Build.0 = Release|x64
+		{C106A864-1897-4D38-818A-48C2D6152B60}.Release|x64.ActiveCfg = Release|x64
+		{C106A864-1897-4D38-818A-48C2D6152B60}.Release|x64.Build.0 = Release|x64
+		{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}.Debug|ARM64.ActiveCfg = Debug|x64
+		{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}.Debug|ARM64.Build.0 = Debug|x64
+		{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}.Debug|Win32.ActiveCfg = Debug|x64
+		{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}.Debug|Win32.Build.0 = Debug|x64
+		{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}.Debug|x64.ActiveCfg = Debug|x64
+		{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}.Debug|x64.Build.0 = Debug|x64
+		{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}.Release|ARM64.ActiveCfg = Release|x64
+		{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}.Release|ARM64.Build.0 = Release|x64
+		{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}.Release|Win32.ActiveCfg = Release|x64
+		{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}.Release|Win32.Build.0 = Release|x64
+		{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}.Release|x64.ActiveCfg = Release|x64
+		{DF47EF11-995E-4B38-BA5C-5F3C6B6178B0}.Release|x64.Build.0 = Release|x64
+		{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}.Debug|ARM64.ActiveCfg = Debug|x64
+		{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}.Debug|ARM64.Build.0 = Debug|x64
+		{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}.Debug|Win32.ActiveCfg = Debug|x64
+		{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}.Debug|Win32.Build.0 = Debug|x64
+		{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}.Debug|x64.ActiveCfg = Debug|x64
+		{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}.Debug|x64.Build.0 = Debug|x64
+		{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}.Release|ARM64.ActiveCfg = Release|x64
+		{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}.Release|ARM64.Build.0 = Release|x64
+		{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}.Release|Win32.ActiveCfg = Release|x64
+		{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}.Release|Win32.Build.0 = Release|x64
+		{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}.Release|x64.ActiveCfg = Release|x64
+		{DECD39B5-3B55-4D6D-A0FA-88A0D37F1578}.Release|x64.Build.0 = Release|x64
 		{F7316F57-89E3-4BC7-A642-8B000EA06C44}.Debug|ARM64.ActiveCfg = Debug|ARM64
 		{F7316F57-89E3-4BC7-A642-8B000EA06C44}.Debug|ARM64.Build.0 = Debug|ARM64
 		{F7316F57-89E3-4BC7-A642-8B000EA06C44}.Debug|Win32.ActiveCfg = Debug|Win32

--- a/ctsTraffic.sln
+++ b/ctsTraffic.sln
@@ -27,6 +27,14 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsIOPatternRateLimitPolicy
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaStreamServerConnectedSocketUnitTest", "MSTest\ctsMediaStreamServerConnectedSocketUnitTest\ctsMediaStreamServerConnectedSocketUnitTest.vcxproj", "{47AB4470-4617-47FA-9529-3A1D1DA7FAA0}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaUploadServerConnectedSocketUnitTest", "MSTest\ctsMediaUploadServerConnectedSocketUnitTest\ctsMediaUploadServerConnectedSocketUnitTest.vcxproj", "{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0001}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaUploadServerListeningSocketUnitTest", "MSTest\ctsMediaUploadServerListeningSocketUnitTest\ctsMediaUploadServerListeningSocketUnitTest.vcxproj", "{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0002}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaUploadServerUnitTest", "MSTest\ctsMediaUploadServerUnitTest\ctsMediaUploadServerUnitTest.vcxproj", "{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0003}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsMediaUploadClientUnitTest", "MSTest\ctsMediaUploadClientUnitTest\ctsMediaUploadClientUnitTest.vcxproj", "{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0004}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UnitTests", "UnitTests", "{F6BA338C-59FD-4354-9F13-1B5511486DC9}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ctsPerf", "ctsPerf\ctsPerf.vcxproj", "{F7316F57-89E3-4BC7-A642-8B000EA06C44}"
@@ -136,6 +144,18 @@ Global
 		{47AB4470-4617-47FA-9529-3A1D1DA7FAA0}.Release|ARM64.ActiveCfg = Release|ARM64
 		{47AB4470-4617-47FA-9529-3A1D1DA7FAA0}.Release|Win32.ActiveCfg = Release|Win32
 		{47AB4470-4617-47FA-9529-3A1D1DA7FAA0}.Release|x64.ActiveCfg = Release|x64
+		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0001}.Debug|x64.ActiveCfg = Debug|x64
+		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0001}.Debug|x64.Build.0 = Debug|x64
+		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0001}.Release|x64.ActiveCfg = Release|x64
+		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0002}.Debug|x64.ActiveCfg = Debug|x64
+		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0002}.Debug|x64.Build.0 = Debug|x64
+		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0002}.Release|x64.ActiveCfg = Release|x64
+		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0003}.Debug|x64.ActiveCfg = Debug|x64
+		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0003}.Debug|x64.Build.0 = Debug|x64
+		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0003}.Release|x64.ActiveCfg = Release|x64
+		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0004}.Debug|x64.ActiveCfg = Debug|x64
+		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0004}.Debug|x64.Build.0 = Debug|x64
+		{A1B3D8B4-1234-4EBD-9EA1-FAKEGUID0004}.Release|x64.ActiveCfg = Release|x64
 		{F7316F57-89E3-4BC7-A642-8B000EA06C44}.Debug|ARM64.ActiveCfg = Debug|ARM64
 		{F7316F57-89E3-4BC7-A642-8B000EA06C44}.Debug|ARM64.Build.0 = Debug|ARM64
 		{F7316F57-89E3-4BC7-A642-8B000EA06C44}.Debug|Win32.ActiveCfg = Debug|Win32

--- a/ctsTraffic/ctsConfig.cpp
+++ b/ctsTraffic/ctsConfig.cpp
@@ -995,32 +995,52 @@ namespace ctsTraffic::ctsConfig
 			});
 		if (foundArgument != end(args))
 		{
-			if (g_configSettings->Protocol != ProtocolType::TCP)
-			{
-				throw invalid_argument("-pattern (only applicable to TCP)");
-			}
-
 			const auto* const value = ParseArgument(*foundArgument, L"-pattern");
-			if (ctString::iordinal_equals(L"push", value))
+
+			if (g_configSettings->Protocol == ProtocolType::TCP)
 			{
-				g_configSettings->IoPattern = IoPatternType::Push;
+				if (ctString::iordinal_equals(L"push", value))
+				{
+					g_configSettings->IoPattern = IoPatternType::Push;
+				}
+				else if (ctString::iordinal_equals(L"pull", value))
+				{
+					g_configSettings->IoPattern = IoPatternType::Pull;
+				}
+				else if (ctString::iordinal_equals(L"pushpull", value))
+				{
+					g_configSettings->IoPattern = IoPatternType::PushPull;
+				}
+				else if (ctString::iordinal_equals(L"flood", value) || ctString::iordinal_equals(L"duplex", value))
+				{
+					// the old name for this was 'flood'
+					g_configSettings->IoPattern = IoPatternType::Duplex;
+				}
+				else
+				{
+					throw invalid_argument("-pattern");
+				}
 			}
-			else if (ctString::iordinal_equals(L"pull", value))
+			else if (g_configSettings->Protocol == ProtocolType::UDP)
 			{
-				g_configSettings->IoPattern = IoPatternType::Pull;
-			}
-			else if (ctString::iordinal_equals(L"pushpull", value))
-			{
-				g_configSettings->IoPattern = IoPatternType::PushPull;
-			}
-			else if (ctString::iordinal_equals(L"flood", value) || ctString::iordinal_equals(L"duplex", value))
-			{
-				// the old name for this was 'flood'
-				g_configSettings->IoPattern = IoPatternType::Duplex;
+				// For UDP, map push -> MediaUpload (client->server uploads)
+				// and pull -> MediaStream (server->client media stream)
+				if (ctString::iordinal_equals(L"push", value))
+				{
+					g_configSettings->IoPattern = IoPatternType::MediaUpload;
+				}
+				else if (ctString::iordinal_equals(L"pull", value))
+				{
+					g_configSettings->IoPattern = IoPatternType::MediaStream;
+				}
+				else
+				{
+					throw invalid_argument("-pattern");
+				}
 			}
 			else
 			{
-				throw invalid_argument("-pattern");
+				throw invalid_argument("-pattern (only applicable to TCP/UDP)");
 			}
 
 			// always remove the arg from our vector

--- a/ctsTraffic/ctsConfig.h
+++ b/ctsTraffic/ctsConfig.h
@@ -81,6 +81,7 @@ namespace ctsTraffic
             Pull,
             PushPull,
             Duplex,
+            MediaUpload,
             MediaStream
         };
 

--- a/ctsTraffic/ctsConfig.h
+++ b/ctsTraffic/ctsConfig.h
@@ -92,6 +92,9 @@ namespace ctsTraffic
             RssAligned,
             Manual
         };
+       
+        // Helper: true when the configured IO pattern is a media-style pattern
+        bool IsMediaPattern(IoPatternType pattern) noexcept;
 
         enum class StatusFormatting : std::uint8_t
         {

--- a/ctsTraffic/ctsIOPattern.cpp
+++ b/ctsTraffic/ctsIOPattern.cpp
@@ -115,6 +115,12 @@ namespace ctsTraffic
                 return make_shared<ctsIoPatternMediaStreamServer>();
             }
             return make_shared<ctsIoPatternMediaStreamClient>();
+        case ctsConfig::IoPatternType::MediaUpload:
+            if (ctsConfig::IsListening())
+            {
+                return make_shared<ctsIoPatternMediaUploadServer>();
+            }
+            return make_shared<ctsIoPatternMediaUploadClient>();
 
         case ctsConfig::IoPatternType::NoIoSet: // fall through
         default: // NOLINT(clang-diagnostic-covered-switch-default)
@@ -1171,4 +1177,6 @@ namespace ctsTraffic
         }
         return ctsIoPatternError::NoError;
     }
+
+        // MediaUpload implementations are in ctsIOPatternMediaUpload.cpp
 } //namespace

--- a/ctsTraffic/ctsIOPatternMediaUpload.cpp
+++ b/ctsTraffic/ctsIOPatternMediaUpload.cpp
@@ -1,0 +1,134 @@
+/*
+  MediaUpload IoPattern implementations
+*/
+
+// cpp headers
+#include <algorithm>
+#include <vector>
+// os headers
+#include <Windows.h>
+// ctl headers
+#include <ctTimer.hpp>
+// project headers
+#include "ctsIOPattern.h"
+#include "ctsStatistics.hpp"
+#include "ctsConfig.h"
+#include "ctsIOTask.hpp"
+#include "ctsMediaStreamProtocol.hpp"
+// wil headers always included last
+#include <wil/stl.h>
+#include <wil/resource.h>
+
+using namespace ctl;
+using std::vector;
+
+namespace ctsTraffic
+{
+// MediaUpload Server: behaves like MediaStreamClient (it receives uploads from clients)
+ctsIoPatternMediaUploadServer::ctsIoPatternMediaUploadServer() noexcept :
+    ctsIoPatternStatistics(ctsConfig::g_configSettings->PrePostRecvs),
+    m_frameSizeBytes(ctsConfig::GetMediaStream().FrameSizeBytes),
+    m_frameRateFps(ctsConfig::GetMediaStream().FramesPerSecond)
+{
+    PRINT_DEBUG_INFO(L"\t\tctsIoPatternMediaUploadServer - frame rate in milliseconds per frame : %lld\n", static_cast<int64_t>(1000UL / m_frameRateFps));
+}
+
+ctsTask ctsIoPatternMediaUploadServer::GetNextTaskFromPattern() noexcept
+{
+    ctsTask returnTask;
+    if (m_recvNeeded > 0)
+    {
+        --m_recvNeeded;
+        returnTask = CreateTrackedTask(ctsTaskAction::Recv, m_frameSizeBytes);
+    }
+    return returnTask;
+}
+
+ctsIoPatternError ctsIoPatternMediaUploadServer::CompleteTaskBackToPattern(const ctsTask& task, uint32_t currentTransfer) noexcept
+{
+    if (task.m_bufferType != ctsTask::BufferType::UdpConnectionId)
+    {
+        const int64_t currentTransferBits = static_cast<int64_t>(currentTransfer) * 8LL;
+
+        ctsConfig::g_configSettings->UdpStatusDetails.m_bitsReceived.Add(currentTransferBits);
+        m_statistics.m_bitsReceived.Add(currentTransferBits);
+
+        m_currentFrameCompleted += currentTransfer;
+        if (m_currentFrameCompleted == m_frameSizeBytes)
+        {
+            ++m_currentFrame;
+            m_currentFrameRequested = 0UL;
+            m_currentFrameCompleted = 0UL;
+        }
+    }
+    return ctsIoPatternError::NoError;
+}
+
+// MediaUpload Client: behaves like MediaStreamServer (it sends uploads to server)
+ctsIoPatternMediaUploadClient::ctsIoPatternMediaUploadClient() :
+    ctsIoPatternStatistics(1), // the pattern will use the recv writeable-buffer for sending a connection ID
+    m_frameSizeBytes(ctsConfig::GetMediaStream().FrameSizeBytes),
+    m_frameRateFps(ctsConfig::GetMediaStream().FramesPerSecond)
+{
+    PRINT_DEBUG_INFO(L"\t\tctsIoPatternMediaUploadClient - frame rate in milliseconds per frame : %lld\n", static_cast<int64_t>(1000UL / m_frameRateFps));
+}
+
+ctsIoPatternMediaUploadClient::~ctsIoPatternMediaUploadClient() noexcept
+{
+}
+
+ctsTask ctsIoPatternMediaUploadClient::GetNextTaskFromPattern() noexcept
+{
+    ctsTask returnTask;
+    switch (m_state)
+    {
+    case ServerState::NotStarted:
+        // send a connection id by using a writeable buffer from the base (Recv) then turn into Send
+        returnTask = ctsMediaStreamMessage::MakeConnectionIdTask(
+            CreateUntrackedTask(ctsTaskAction::Recv, c_udpDatagramConnectionIdHeaderLength),
+            GetConnectionIdentifier());
+        m_state = ServerState::IdSent;
+        break;
+
+    case ServerState::IdSent:
+        m_baseTimeMilliseconds = ctTimer::snap_qpc_as_msec();
+        m_state = ServerState::IoStarted;
+        [[fallthrough]];
+    case ServerState::IoStarted:
+        if (m_currentFrameRequested < m_frameSizeBytes)
+        {
+            returnTask = CreateTrackedTask(ctsTaskAction::Send, m_frameSizeBytes);
+            // calculate the future time to initiate the IO
+            returnTask.m_timeOffsetMilliseconds =
+                m_baseTimeMilliseconds
+                + (m_currentFrame * 1000LL / m_frameRateFps)
+                - ctTimer::snap_qpc_as_msec();
+
+            m_currentFrameRequested += returnTask.m_bufferLength;
+        }
+        break;
+    }
+    return returnTask;
+}
+
+ctsIoPatternError ctsIoPatternMediaUploadClient::CompleteTaskBackToPattern(const ctsTask& task, uint32_t currentTransfer) noexcept
+{
+    if (task.m_bufferType != ctsTask::BufferType::UdpConnectionId)
+    {
+        const int64_t currentTransferBits = static_cast<int64_t>(currentTransfer) * 8LL;
+
+        ctsConfig::g_configSettings->UdpStatusDetails.m_bitsReceived.Add(currentTransferBits);
+        m_statistics.m_bitsReceived.Add(currentTransferBits);
+
+        m_currentFrameCompleted += currentTransfer;
+        if (m_currentFrameCompleted == m_frameSizeBytes)
+        {
+            ++m_currentFrame;
+            m_currentFrameRequested = 0UL;
+            m_currentFrameCompleted = 0UL;
+        }
+    }
+    return ctsIoPatternError::NoError;
+}
+
+} // namespace ctsTraffic

--- a/ctsTraffic/ctsMediaUploadClient.cpp
+++ b/ctsTraffic/ctsMediaUploadClient.cpp
@@ -1,0 +1,438 @@
+/*
+Upload client implementation - based on ctsMediaStreamClient
+*/
+// cpp headers
+#include <memory>
+// os headers
+#include <Windows.h>
+#include <WinSock2.h>
+// ctl headers
+#include <ctSockaddr.hpp>
+// project headers
+#include "ctsMediaUploadProtocol.hpp"
+#include "ctsMediaUploadClient.h"
+#include "ctsWinsockLayer.h"
+#include "ctsIOTask.hpp"
+#include "ctsIOPattern.h"
+#include "ctsSocket.h"
+#include "ctsConfig.h"
+// wil headers always included last
+#include <wil/stl.h>
+#include <wil/resource.h>
+
+namespace ctsTraffic
+{
+    struct IoImplStatus
+    {
+        int m_errorCode = 0;
+        bool m_continueIo = false;
+    };
+
+    static IoImplStatus ctsMediaUploadClientIoImpl(
+        const std::shared_ptr<ctsSocket>& sharedSocket,
+        SOCKET socket,
+        const std::shared_ptr<ctsIoPattern>& lockedPattern,
+        const ctsTask& task) noexcept;
+
+    static void ctsMediaUploadClientIoCompletionCallback(
+        _In_ OVERLAPPED* pOverlapped,
+        const std::weak_ptr<ctsSocket>& weakSocket,
+        const ctsTask& task
+    ) noexcept;
+
+    static void ctsMediaUploadClientConnectionCompletionCallback(
+        _In_ OVERLAPPED* pOverlapped,
+        const std::weak_ptr<ctsSocket>& weakSocket,
+        const ctl::ctSockaddr& targetAddress
+    ) noexcept;
+
+    void ctsMediaUploadClient(const std::weak_ptr<ctsSocket>& weakSocket) noexcept
+    {
+        const auto sharedSocket(weakSocket.lock());
+        if (!sharedSocket)
+        {
+            return;
+        }
+
+        const auto lockedSocket = sharedSocket->AcquireSocketLock();
+        const auto lockedPattern = lockedSocket.GetPattern();
+        if (!lockedPattern || lockedSocket.GetSocket() == INVALID_SOCKET)
+        {
+            return;
+        }
+
+        lockedPattern->RegisterCallback(
+            [weakSocket](const ctsTask& task) noexcept
+            {
+                const auto lambdaSharedSocket(weakSocket.lock());
+                if (!lambdaSharedSocket)
+                {
+                    return;
+                }
+
+                const auto lambdaLockedSocket = lambdaSharedSocket->AcquireSocketLock();
+                const auto lambdaLockedPattern = lambdaLockedSocket.GetPattern();
+                if (!lambdaLockedPattern || lambdaLockedSocket.GetSocket() == INVALID_SOCKET)
+                {
+                    return;
+                }
+
+                if (lambdaSharedSocket->IncrementIo() > 1)
+                {
+                    const IoImplStatus status = ctsMediaUploadClientIoImpl(
+                        lambdaSharedSocket, lambdaLockedSocket.GetSocket(), lambdaLockedPattern, task);
+                    if (lambdaSharedSocket->DecrementIo() == 0)
+                    {
+                        lambdaSharedSocket->CompleteState(status.m_errorCode);
+                    }
+                }
+                else
+                {
+                    lambdaSharedSocket->DecrementIo();
+                }
+            });
+
+        sharedSocket->IncrementIo();
+        IoImplStatus status = ctsMediaUploadClientIoImpl(
+            sharedSocket,
+            lockedSocket.GetSocket(),
+            lockedPattern,
+            lockedPattern->InitiateIo());
+        while (status.m_continueIo)
+        {
+            status = ctsMediaUploadClientIoImpl(
+                sharedSocket,
+                lockedSocket.GetSocket(),
+                lockedPattern,
+                lockedPattern->InitiateIo());
+        }
+        if (0 == sharedSocket->DecrementIo())
+        {
+            sharedSocket->CompleteState(status.m_errorCode);
+        }
+    }
+
+    void ctsMediaUploadClientConnect(const std::weak_ptr<ctsSocket>& weakSocket) noexcept
+    {
+        const auto sharedSocket(weakSocket.lock());
+        if (!sharedSocket)
+        {
+            return;
+        }
+
+        const auto lockedSocket = sharedSocket->AcquireSocketLock();
+        if (lockedSocket.GetSocket() == INVALID_SOCKET)
+        {
+            sharedSocket->CompleteState(WSAECONNABORTED);
+            return;
+        }
+
+        const auto socket = lockedSocket.GetSocket();
+        const ctl::ctSockaddr targetAddress(sharedSocket->GetRemoteSockaddr());
+        const ctsTask startTask = ctsMediaUploadMessage::Construct(MediaUploadAction::START);
+
+        const auto response = ctsWSASendTo(
+            sharedSocket,
+            lockedSocket.GetSocket(),
+            startTask,
+            [weakSocket, targetAddress](OVERLAPPED* ov) noexcept
+            {
+                ctsMediaUploadClientConnectionCompletionCallback(ov, weakSocket, targetAddress);
+            });
+
+        if (NO_ERROR == response.m_errorCode)
+        {
+            ctl::ctSockaddr localAddr;
+            auto localAddrLen = localAddr.length();
+            if (0 == getsockname(socket, localAddr.sockaddr(), &localAddrLen))
+            {
+                sharedSocket->SetLocalSockaddr(localAddr);
+            }
+            sharedSocket->SetRemoteSockaddr(targetAddress);
+
+            ctsConfig::SetPostConnectOptions(socket, targetAddress);
+
+            ctsConfig::PrintNewConnection(localAddr, targetAddress);
+
+            PRINT_DEBUG_INFO(
+                L"\t\tctsMediaUploadClient sent its START message to %ws\n",
+                targetAddress.writeCompleteAddress().c_str());
+        }
+
+        if (response.m_errorCode != WSA_IO_PENDING)
+        {
+            sharedSocket->CompleteState(response.m_errorCode);
+        }
+    }
+
+    IoImplStatus ctsMediaUploadClientIoImpl(
+        const std::shared_ptr<ctsSocket>& sharedSocket,
+        SOCKET socket,
+        const std::shared_ptr<ctsIoPattern>& lockedPattern,
+        const ctsTask& task) noexcept
+    {
+        IoImplStatus returnStatus;
+
+        switch (task.m_ioAction)
+        {
+        case ctsTaskAction::Send:
+            [[fallthrough]];
+        case ctsTaskAction::Recv:
+            {
+                sharedSocket->IncrementIo();
+                auto callback = [weak_reference = std::weak_ptr(sharedSocket), task](OVERLAPPED* ov) noexcept
+                {
+                    ctsMediaUploadClientIoCompletionCallback(ov, weak_reference, task);
+                };
+
+                PCSTR functionName{};
+                wsIOResult result;
+                if (ctsTaskAction::Send == task.m_ioAction)
+                {
+                    functionName = "WSASendTo";
+                    result = ctsWSASendTo(sharedSocket, socket, task, std::move(callback));
+                }
+                else if (ctsTaskAction::Recv == task.m_ioAction)
+                {
+                    functionName = "WSARecvFrom";
+                    result = ctsWSARecvFrom(sharedSocket, socket, task, std::move(callback));
+                }
+                else
+                {
+                    FAIL_FAST_MSG(
+                        "ctsMediaUploadClientIoImpl: received an unexpected IOStatus in the ctsIOTask (%p)", &task);
+                }
+
+                if (WSA_IO_PENDING == result.m_errorCode)
+                {
+                    returnStatus.m_errorCode = static_cast<int>(result.m_errorCode);
+                    returnStatus.m_continueIo = true;
+                }
+                else
+                {
+                    if (result.m_errorCode != 0)
+                    {
+                        PRINT_DEBUG_INFO(L"\t\tIO Failed: %hs (%u) [ctsMediaUploadClient]\n",
+                                         functionName,
+                                         result.m_errorCode);
+                    }
+
+                    switch (const auto protocolStatus = lockedPattern->CompleteIo(
+                        task, result.m_bytesTransferred, result.m_errorCode))
+                    {
+                    case ctsIoStatus::ContinueIo:
+                        returnStatus.m_errorCode = NO_ERROR;
+                        returnStatus.m_continueIo = true;
+                        break;
+
+                    case ctsIoStatus::CompletedIo:
+                        sharedSocket->CloseSocket();
+                        returnStatus.m_errorCode = NO_ERROR;
+                        returnStatus.m_continueIo = false;
+                        break;
+
+                    case ctsIoStatus::FailedIo:
+                        ctsConfig::PrintErrorIfFailed(functionName, result.m_errorCode);
+                        sharedSocket->CloseSocket();
+                        returnStatus.m_errorCode = static_cast<int>(lockedPattern->GetLastPatternError());
+                        returnStatus.m_continueIo = false;
+                        break;
+
+                    default:
+                        FAIL_FAST_MSG("ctsMediaUploadClientIoImpl: unknown ctsSocket::IOStatus - %d\n", protocolStatus);
+                    }
+
+                    const auto ioCount = sharedSocket->DecrementIo();
+                    FAIL_FAST_IF_MSG(
+                        0 == ioCount,
+                        "ctsMediaUploadClient : ctsSocket::io_count fell to zero while the Impl function was called (dt %p ctsTraffic::ctsSocket)",
+                        sharedSocket.get());
+                }
+
+                break;
+            }
+
+        case ctsTaskAction::None:
+            {
+                returnStatus.m_errorCode = NO_ERROR;
+                returnStatus.m_continueIo = false;
+                break;
+            }
+
+        case ctsTaskAction::Abort:
+            {
+                lockedPattern->CompleteIo(task, 0, 0);
+                sharedSocket->CloseSocket();
+
+                returnStatus.m_errorCode = NO_ERROR;
+                returnStatus.m_continueIo = false;
+                break;
+            }
+
+        case ctsTaskAction::FatalAbort:
+            {
+                lockedPattern->CompleteIo(task, 0, 0);
+                sharedSocket->CloseSocket();
+
+                returnStatus.m_errorCode = static_cast<int>(lockedPattern->GetLastPatternError());
+                returnStatus.m_continueIo = false;
+                break;
+            }
+
+        case ctsTaskAction::GracefulShutdown:
+        case ctsTaskAction::HardShutdown:
+        default:
+            break;
+        }
+
+        return returnStatus;
+    }
+
+    void ctsMediaUploadClientIoCompletionCallback(
+        _In_ OVERLAPPED* pOverlapped,
+        const std::weak_ptr<ctsSocket>& weakSocket,
+        const ctsTask& task) noexcept
+    {
+        const auto sharedSocket(weakSocket.lock());
+        if (!sharedSocket)
+        {
+            return;
+        }
+
+        const auto lockedSocket = sharedSocket->AcquireSocketLock();
+        const auto lockedPattern = lockedSocket.GetPattern();
+        if (!lockedPattern)
+        {
+            sharedSocket->DecrementIo();
+            sharedSocket->CompleteState(WSAECONNABORTED);
+            return;
+        }
+
+        const auto socket = lockedSocket.GetSocket();
+
+        int gle = NO_ERROR;
+        DWORD transferred = 0;
+        {
+            if (socket != INVALID_SOCKET)
+            {
+                DWORD flags;
+                if (!WSAGetOverlappedResult(socket, pOverlapped, &transferred, FALSE, &flags))
+                {
+                    gle = WSAGetLastError();
+                }
+            }
+            else
+            {
+                gle = NO_ERROR;
+            }
+        }
+
+        if (gle == WSAEMSGSIZE)
+        {
+            ctsConfig::PrintErrorInfo(
+                L"MediaUpload Client: %ws failed with WSAEMSGSIZE: received [%u bytes]",
+                task.m_ioAction == ctsTaskAction::Recv ? L"WSARecvFrom" : L"WSASendTo", transferred);
+            gle = NO_ERROR;
+        }
+
+        switch (const ctsIoStatus protocolStatus = lockedPattern->CompleteIo(task, transferred, gle))
+        {
+        case ctsIoStatus::ContinueIo:
+            {
+                IoImplStatus status;
+                do
+                {
+                    status = ctsMediaUploadClientIoImpl(
+                        sharedSocket,
+                        lockedSocket.GetSocket(),
+                        lockedPattern,
+                        lockedPattern->InitiateIo());
+                }
+                while (status.m_continueIo);
+
+                gle = status.m_errorCode;
+                break;
+            }
+
+        case ctsIoStatus::CompletedIo:
+            sharedSocket->CloseSocket();
+            gle = NO_ERROR;
+            break;
+
+        case ctsIoStatus::FailedIo:
+            if (gle != 0)
+            {
+                ctsConfig::PrintErrorInfo(
+                    L"MediaUpload Client: IO failed (%ws) with error %d",
+                    task.m_ioAction == ctsTaskAction::Recv ? L"WSARecvFrom" : L"WSASendTo", gle);
+            }
+            else
+            {
+                ctsConfig::PrintErrorInfo(
+                    L"MediaUpload Client: IO succeeded (%ws) but the ctsIOProtocol failed the stream (%u)",
+                    task.m_ioAction == ctsTaskAction::Recv ? L"WSARecvFrom" : L"WSASendTo",
+                    lockedPattern->GetLastPatternError());
+            }
+
+            sharedSocket->CloseSocket();
+            gle = static_cast<int>(lockedPattern->GetLastPatternError());
+            break;
+
+        default:
+            FAIL_FAST_MSG(
+                "ctsMediaUploadClientIoCompletionCallback: unknown ctsSocket::IOStatus - %d\n",
+                protocolStatus);
+        }
+
+        if (sharedSocket->DecrementIo() == 0)
+        {
+            sharedSocket->CompleteState(gle);
+        }
+    }
+
+    void ctsMediaUploadClientConnectionCompletionCallback(
+        _In_ OVERLAPPED* pOverlapped,
+        const std::weak_ptr<ctsSocket>& weakSocket,
+        const ctl::ctSockaddr& targetAddress) noexcept
+    {
+        const auto sharedSocket(weakSocket.lock());
+        if (!sharedSocket)
+        {
+            return;
+        }
+
+        int gle = NO_ERROR;
+        const auto lockedSocket = sharedSocket->AcquireSocketLock();
+        const auto socket = lockedSocket.GetSocket();
+        if (socket == INVALID_SOCKET)
+        {
+            gle = WSAECONNABORTED;
+        }
+        else
+        {
+            DWORD transferred;
+            DWORD flags;
+            if (!WSAGetOverlappedResult(socket, pOverlapped, &transferred, FALSE, &flags))
+            {
+                gle = WSAGetLastError();
+            }
+        }
+
+        ctsConfig::PrintErrorIfFailed("\tWSASendTo (START request)", gle);
+
+        if (NO_ERROR == gle)
+        {
+            ctl::ctSockaddr localAddr;
+            int localAddrLen = localAddr.length();
+            if (0 == getsockname(socket, localAddr.sockaddr(), &localAddrLen))
+            {
+                sharedSocket->SetLocalSockaddr(localAddr);
+            }
+            sharedSocket->SetRemoteSockaddr(targetAddress);
+            ctsConfig::SetPostConnectOptions(socket, targetAddress);
+            ctsConfig::PrintNewConnection(localAddr, targetAddress);
+        }
+
+        sharedSocket->CompleteState(gle);
+    }
+} // namespace

--- a/ctsTraffic/ctsMediaUploadClient.h
+++ b/ctsTraffic/ctsMediaUploadClient.h
@@ -1,0 +1,18 @@
+/*
+Header for upload client
+*/
+#pragma once
+
+// cpp headers
+#include <memory>
+// local headers
+#include "ctsSocket.h"
+
+namespace ctsTraffic
+{
+// The function that is registered to run Winsock IO using IO Completion Ports with the specified ctsSocket
+void ctsMediaUploadClient(const std::weak_ptr<ctsSocket>& weakSocket) noexcept;
+
+// The function that is registered to 'connect' to the target server by sending a START command using IO Completion Ports
+void ctsMediaUploadClientConnect(const std::weak_ptr<ctsSocket>& weakSocket) noexcept;
+} // namespace

--- a/ctsTraffic/ctsMediaUploadProtocol.hpp
+++ b/ctsTraffic/ctsMediaUploadProtocol.hpp
@@ -1,0 +1,442 @@
+/*
+
+Copyright (c) Microsoft Corporation
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the ""License""); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions and limitations under the License.
+
+*/
+
+// ReSharper disable CppInconsistentNaming
+#pragma once
+
+// cpp headers
+#include <array>
+#include <string>
+// os headers
+#include <Windows.h>
+#include <WinSock2.h>
+// ctl headers
+#include <ctTimer.hpp>
+// project headers
+#include "ctsConfig.h"
+#include "ctsIOTask.hpp"
+#include "ctsStatistics.hpp"
+// wil headers always included last
+#include <wil/resource.h>
+
+namespace ctsTraffic
+{
+//
+// ctsMediaUploadMessage encapsulates requests sent from clients for upload
+//
+// Grammar:
+//
+//   REQUEST_ID
+//   START
+//
+constexpr uint16_t c_udpDatagramProtocolHeaderFlagData = 0x0000;
+constexpr uint16_t c_udpDatagramProtocolHeaderFlagId = 0x1000;
+
+constexpr uint32_t c_udpDatagramProtocolHeaderFlagLength = 2;
+constexpr uint32_t c_udpDatagramConnectionIdHeaderLength = c_udpDatagramProtocolHeaderFlagLength + ctsStatistics::ConnectionIdLength;
+
+constexpr uint32_t c_udpDatagramSequenceNumberLength = 8; // 64-bit value
+constexpr uint32_t c_udpDatagramQpcLength = 8; // 64-bit value
+constexpr uint32_t c_udpDatagramQpfLength = 8; // 64-bit value
+constexpr uint32_t c_udpDatagramDataHeaderLength = c_udpDatagramProtocolHeaderFlagLength + c_udpDatagramSequenceNumberLength + c_udpDatagramQpcLength + c_udpDatagramQpfLength;
+
+static auto* g_udpDatagramUploadStartString = "START";
+constexpr uint32_t c_udpDatagramStartStringLength = 5;
+
+enum class MediaUploadAction : char
+{
+    START
+};
+
+class ctsMediaUploadSendRequests
+{
+public:
+    ~ctsMediaUploadSendRequests() = default;
+    ctsMediaUploadSendRequests() = delete;
+    ctsMediaUploadSendRequests(const ctsMediaUploadSendRequests&) = delete;
+    ctsMediaUploadSendRequests& operator=(const ctsMediaUploadSendRequests&) = delete;
+    ctsMediaUploadSendRequests(ctsMediaUploadSendRequests&&) = delete;
+    ctsMediaUploadSendRequests& operator=(ctsMediaUploadSendRequests&&) = delete;
+
+
+    static constexpr uint32_t c_bufferArraySize = 5;
+    //
+    // compose iteration across buffers to be sent per instantiated request
+    //
+    class iterator
+    {
+    public:
+        // iterator_traits
+        // - allows <algorithm> functions to be used
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = std::array<WSABUF, c_bufferArraySize>;
+        using difference_type = size_t;
+        using pointer = std::array<WSABUF, c_bufferArraySize>*;
+        using reference = std::array<WSABUF, c_bufferArraySize>&;
+
+        ~iterator() = default;
+        iterator(const iterator&) = default;
+        iterator& operator=(const iterator&) = default;
+        iterator(iterator&&) = default;
+        iterator& operator=(iterator&&) = default;
+
+        // Dereferencing operators
+        // - returning non-const array references as Winsock APIs don't take const WSABUF*
+        std::array<WSABUF, c_bufferArraySize>* operator->() noexcept
+        {
+            FAIL_FAST_IF_MSG(
+                nullptr == m_qpcAddress,
+                "Invalid ctsMediaUploadSendRequests::iterator being dereferenced (%p)", this);
+
+            // refresh the QPC value at the last possible moment before returning the array to the user
+            _Analysis_assume_(m_qpcAddress != nullptr);
+            QueryPerformanceCounter(m_qpcAddress);
+            return &m_wsaBufArray;
+        }
+
+        std::array<WSABUF, c_bufferArraySize>& operator*() noexcept
+        {
+            FAIL_FAST_IF_MSG(
+                nullptr == m_qpcAddress,
+                "Invalid ctsMediaUploadSendRequests::iterator being dereferenced (%p)", this);
+
+            // refresh the QPC value at the last possible moment before returning the array to the user
+            _Analysis_assume_(m_qpcAddress != nullptr);
+            QueryPerformanceCounter(m_qpcAddress);
+            return m_wsaBufArray;
+        }
+
+        bool operator ==(const iterator& comparand) const noexcept
+        {
+            return m_qpcAddress == comparand.m_qpcAddress &&
+                   m_bytesToSend == comparand.m_bytesToSend;
+        }
+
+        bool operator !=(const iterator& comparand) const noexcept
+        {
+            return !(*this == comparand);
+        }
+
+        iterator& operator++() noexcept
+        {
+            FAIL_FAST_IF_MSG(
+                nullptr == m_qpcAddress,
+                "Invalid ctsMediaUploadSendRequests::iterator being dereferenced (%p)", this);
+
+            // if bytes is zero, then increment to the end() iterator
+            if (0 == m_bytesToSend)
+            {
+                m_qpcAddress = nullptr;
+            }
+            else
+            {
+                m_bytesToSend -= this->UpdateBufferLength();
+            }
+
+            return *this;
+        }
+
+        iterator operator++(int) noexcept
+        {
+            const iterator temp(*this);
+            ++*this;
+            return temp;
+        }
+
+    private:
+        // constructor is only available to the begin() and end() methods of ctsMediaUploadSendRequests
+        friend class ctsMediaUploadSendRequests;
+
+        iterator(_In_opt_ LARGE_INTEGER* qpcAddress, int64_t bytesToSend, uint32_t maxDatagramSize, const std::array<WSABUF, c_bufferArraySize>& wsaBufferArray) noexcept :
+            m_qpcAddress(qpcAddress),
+            m_bytesToSend(bytesToSend),
+            m_maxDatagramSize(maxDatagramSize),
+            m_wsaBufArray(wsaBufferArray)
+        {
+            // set the buffer length for the first iterator
+            m_bytesToSend -= this->UpdateBufferLength();
+        }
+
+        uint32_t UpdateBufferLength() noexcept
+        {
+            // only update when not the end() iterator
+            if (m_qpcAddress)
+            {
+                if (m_bytesToSend > m_maxDatagramSize)
+                {
+                    m_wsaBufArray[4].len = m_maxDatagramSize - c_udpDatagramDataHeaderLength;
+                }
+                else
+                {
+                    m_wsaBufArray[4].len = static_cast<uint32_t>(m_bytesToSend - c_udpDatagramDataHeaderLength);
+                }
+
+                auto totalBytesToSend =
+                    m_wsaBufArray[0].len + m_wsaBufArray[1].len + m_wsaBufArray[2].len + m_wsaBufArray[3].len + m_wsaBufArray[4].len;
+
+                // must guarantee that after we send this datagram we have enough bytes for the next send if there are bytes left over
+                const auto bytesRemaining = m_bytesToSend - static_cast<int64_t>(totalBytesToSend);
+                if (bytesRemaining > 0 && bytesRemaining <= c_udpDatagramDataHeaderLength)
+                {
+                    // subtract out enough bytes so the next datagram will be large enough for the header and at least one byte of data
+                    auto newLength = m_wsaBufArray[4].len;
+                    const auto deltaToRemove = c_udpDatagramDataHeaderLength + 1 - static_cast<uint32_t>(bytesRemaining);
+                    newLength -= deltaToRemove;
+
+                    m_wsaBufArray[4].len = newLength;
+                    totalBytesToSend -= deltaToRemove;
+                }
+
+                return totalBytesToSend;
+            }
+
+            return 0UL;
+        }
+
+        LARGE_INTEGER* m_qpcAddress;
+        int64_t m_bytesToSend;
+        uint32_t m_maxDatagramSize;
+        std::array<WSABUF, c_bufferArraySize> m_wsaBufArray;
+    };
+
+
+    //
+    // Constructor of the ctsMediaUploadSendRequests captures the properties of the next Send() request
+    // - the total # of bytes to send (across X number of send requests)
+    // - the sequence number to tag in every send request
+    //
+    ctsMediaUploadSendRequests(int64_t bytesToSend, int64_t sequenceNumber, const char* sendBuffer) noexcept :
+        m_qpf(ctl::ctTimer::snap_qpf()),
+        m_bytesToSend(bytesToSend),
+        m_sequenceNumber(sequenceNumber),
+        m_maxDatagramSize(ctsConfig::GetMediaStream().DatagramMaxSize)
+    {
+        FAIL_FAST_IF_MSG(
+            bytesToSend <= c_udpDatagramDataHeaderLength,
+            "ctsMediaUploadSendRequests requires a buffer size to send larger than the ctsTraffic UDP header");
+
+        // buffer layout: header#, seq. number, qpc, qpf, then the buffered data
+        m_wsaBuffer[0].buf = reinterpret_cast<char*>(const_cast<unsigned short*>(&c_udpDatagramProtocolHeaderFlagData));
+        m_wsaBuffer[0].len = c_udpDatagramProtocolHeaderFlagLength;
+
+        m_wsaBuffer[1].buf = reinterpret_cast<char*>(&m_sequenceNumber);
+        m_wsaBuffer[1].len = c_udpDatagramSequenceNumberLength;
+
+        m_wsaBuffer[2].buf = reinterpret_cast<char*>(&m_qpcValue.QuadPart);
+        m_wsaBuffer[2].len = c_udpDatagramQpcLength;
+
+        m_wsaBuffer[3].buf = reinterpret_cast<char*>(&m_qpf);
+        m_wsaBuffer[3].len = c_udpDatagramQpfLength;
+
+        m_wsaBuffer[4].buf = const_cast<char*>(sendBuffer);
+        // the "this->wsabuf[4].len" field is dependent on bytes_to_send and can change by iterator()
+    }
+
+    [[nodiscard]] iterator begin() noexcept
+    {
+        return {&m_qpcValue, m_bytesToSend, m_maxDatagramSize, m_wsaBuffer};
+    }
+
+    [[nodiscard]] iterator end() const noexcept
+    {
+        // end == null qpc + 0 byte length
+        return {nullptr, 0, 0, m_wsaBuffer};
+    }
+
+
+private:
+    std::array<WSABUF, c_bufferArraySize> m_wsaBuffer{};
+    LARGE_INTEGER m_qpcValue{};
+    int64_t m_qpf;
+    int64_t m_bytesToSend;
+    int64_t m_sequenceNumber;
+    uint32_t m_maxDatagramSize{};
+};
+
+
+struct ctsMediaUploadMessage
+{
+    int64_t m_sequenceNumber = 0ll;
+    MediaUploadAction m_action{};
+
+    explicit ctsMediaUploadMessage(MediaUploadAction action) noexcept :
+        m_action(action)
+    {
+    }
+
+    ~ctsMediaUploadMessage() noexcept = default;
+    ctsMediaUploadMessage(const ctsMediaUploadMessage&) = default;
+    ctsMediaUploadMessage& operator=(const ctsMediaUploadMessage&) = default;
+    ctsMediaUploadMessage(ctsMediaUploadMessage&&) = default;
+    ctsMediaUploadMessage& operator=(ctsMediaUploadMessage&&) = default;
+
+    static bool ValidateBufferLengthFromTask(const ctsTask& task, uint32_t completedBytes) noexcept
+    {
+        if (completedBytes < c_udpDatagramProtocolHeaderFlagLength)
+        {
+            ctsConfig::PrintErrorInfo(
+                L"ctsMediaUploadMessage::ValidateBufferLengthFromTask rejecting the datagram: the datagram size (%u) is less than UdpDatagramProtocolHeaderFlagLength (%u)",
+                completedBytes,
+                c_udpDatagramProtocolHeaderFlagLength);
+            return false;
+        }
+
+        switch (GetProtocolHeaderFromTask(task))
+        {
+            case c_udpDatagramProtocolHeaderFlagData:
+                if (completedBytes < c_udpDatagramDataHeaderLength)
+                {
+                    ctsConfig::PrintErrorInfo(
+                        L"ctsMediaUploadMessage::ValidateBufferLengthFromTask rejecting the datagram type UdpDatagramProtocolHeaderFlagData: the datagram size (%u) is less than UdpDatagramDataHeaderLength (%u)",
+                        completedBytes,
+                        c_udpDatagramDataHeaderLength);
+                    return false;
+                }
+                break;
+
+            case c_udpDatagramProtocolHeaderFlagId:
+                if (completedBytes < c_udpDatagramConnectionIdHeaderLength)
+                {
+                    ctsConfig::PrintErrorInfo(
+                        L"ctsMediaUploadMessage::ValidateBufferLengthFromTask rejecting the datagram type UdpDatagramProtocolHeaderFlagId: the datagram size (%u) is less than UdpDatagramConnectionIdHeaderLength (%u)",
+                        completedBytes,
+                        c_udpDatagramConnectionIdHeaderLength);
+                    return false;
+                }
+                break;
+
+            default:
+                ctsConfig::PrintErrorInfo(
+                    L"ctsMediaUploadMessage::ValidateBufferLengthFromTask rejecting the datagram of unknown frame type (%u) - expecting UdpDatagramProtocolHeaderFlagData (%u) or UdpDatagramProtocolHeaderFlagId (%u)",
+                    GetProtocolHeaderFromTask(task),
+                    c_udpDatagramProtocolHeaderFlagData,
+                    c_udpDatagramProtocolHeaderFlagId);
+                return false;
+        }
+
+        return true;
+    }
+
+    static unsigned short GetProtocolHeaderFromTask(const ctsTask& task) noexcept
+    {
+        return *reinterpret_cast<unsigned short*>(task.m_buffer);
+    }
+
+    static void SetConnectionIdFromTask(_Inout_updates_(ctsStatistics::ConnectionIdLength) char* const connectionId, const ctsTask& task) noexcept
+    {
+        const auto copyError = memcpy_s(
+            connectionId,
+            ctsStatistics::ConnectionIdLength,
+            task.m_buffer + task.m_bufferOffset + c_udpDatagramProtocolHeaderFlagLength,
+            ctsStatistics::ConnectionIdLength);
+        FAIL_FAST_IF_MSG(
+            copyError != 0,
+            "ctsMediaUploadMessage::GetConnectionIdFromTask : memcpy_s failed trying to copy the connection ID - target buffer (%p) ctsIOTask (%p) (error : %d)",
+            connectionId, &task, copyError);
+    }
+
+    static int64_t GetSequenceNumberFromTask(const ctsTask& task) noexcept
+    {
+        int64_t returnValue;
+        const auto copyError = memcpy_s(
+                                        &returnValue,
+                                        c_udpDatagramSequenceNumberLength,
+                                        task.m_buffer + task.m_bufferOffset + c_udpDatagramProtocolHeaderFlagLength,
+                                        c_udpDatagramSequenceNumberLength);
+        FAIL_FAST_IF_MSG(
+            copyError != 0,
+            "ctsMediaUploadMessage::GetSequenceNumberFromTask : memcpy_s failed trying to copy the sequence number - ctsIOTask (%p) (error : %d)",
+            &task, copyError);
+
+        return returnValue;
+    }
+
+    static int64_t GetQueryPerfCounterFromTask(const ctsTask& task) noexcept
+    {
+        int64_t returnValue;
+        const auto copyError = memcpy_s(&returnValue, c_udpDatagramSequenceNumberLength, task.m_buffer + task.m_bufferOffset + c_udpDatagramProtocolHeaderFlagLength, c_udpDatagramSequenceNumberLength);
+        FAIL_FAST_IF_MSG(
+            copyError != 0,
+            "ctsMediaUploadMessage::GetSequenceNumberFromTask : memcpy_s failed trying to copy the sequence number - ctsIOTask (%p) (error : %d)",
+            &task, copyError);
+
+        return returnValue;
+    }
+
+    static int64_t GetQueryPerfFrequencyFromTask(const ctsTask& task) noexcept
+    {
+        int64_t returnValue;
+        const auto copyError = memcpy_s(&returnValue, c_udpDatagramSequenceNumberLength, task.m_buffer + task.m_bufferOffset + c_udpDatagramProtocolHeaderFlagLength, c_udpDatagramSequenceNumberLength);
+        FAIL_FAST_IF_MSG(
+            copyError != 0,
+            "ctsMediaUploadMessage::GetSequenceNumberFromTask : memcpy_s failed trying to copy the sequence number - target buffer (%p) ctsIOTask (%p) (error : %d)",
+            &returnValue, &task, copyError);
+
+        return returnValue;
+    }
+
+    static ctsTask MakeConnectionIdTask(const ctsTask& rawTask, _In_reads_(ctsStatistics::ConnectionIdLength) const char* const connectionId) noexcept
+    {
+        FAIL_FAST_IF_MSG(
+            rawTask.m_bufferLength != ctsStatistics::ConnectionIdLength + c_udpDatagramProtocolHeaderFlagLength,
+            "ctsMediaUploadMessage::GetConnectionIdFromTask : the buffer_length in the provided task (%u) is not the expected buffer length (%u)",
+            rawTask.m_bufferLength, ctsStatistics::ConnectionIdLength + c_udpDatagramProtocolHeaderFlagLength);
+
+        ctsTask returnTask{rawTask};
+        // populate the buffer with the ConnectionId and protocol field
+        memcpy_s(returnTask.m_buffer, c_udpDatagramProtocolHeaderFlagLength, &c_udpDatagramProtocolHeaderFlagId, c_udpDatagramProtocolHeaderFlagLength);
+        memcpy_s(returnTask.m_buffer + c_udpDatagramProtocolHeaderFlagLength, ctsStatistics::ConnectionIdLength, connectionId, ctsStatistics::ConnectionIdLength);
+
+        returnTask.m_ioAction = ctsTaskAction::Send;
+        returnTask.m_bufferType = ctsTask::BufferType::UdpConnectionId;
+        returnTask.m_trackIo = false;
+        return returnTask;
+    }
+
+    static ctsTask Construct(MediaUploadAction action) noexcept
+    {
+        ctsTask returnTask;
+        returnTask.m_ioAction = ctsTaskAction::Send;
+        returnTask.m_bufferType = ctsTask::BufferType::Static;
+        returnTask.m_trackIo = false;
+
+        // safe to const-cast as we are sending these buffers
+        switch (action)
+        {
+            case MediaUploadAction::START:
+                returnTask.m_buffer = const_cast<char*>(g_udpDatagramUploadStartString);
+                returnTask.m_bufferLength = c_udpDatagramStartStringLength;
+                break;
+
+            default: FAIL_FAST();
+        }
+
+        return returnTask;
+    }
+
+    static ctsMediaUploadMessage Extract(_In_reads_bytes_(inputLength) const char* inputBuffer, uint32_t inputLength)
+    {
+        if (inputLength == c_udpDatagramStartStringLength)
+        {
+            if (0 == memcmp(inputBuffer, g_udpDatagramUploadStartString, c_udpDatagramStartStringLength))
+            {
+                return ctsMediaUploadMessage(MediaUploadAction::START);
+            }
+        }
+
+        THROW_HR_MSG(HRESULT_FROM_WIN32(ERROR_INVALID_DATA),
+            "Invalid MediaUpload message: %hs",
+            std::string(inputBuffer, inputLength).c_str());
+    }
+};
+}

--- a/ctsTraffic/ctsMediaUploadServer.cpp
+++ b/ctsTraffic/ctsMediaUploadServer.cpp
@@ -1,0 +1,461 @@
+/*
+Upload server implementation - based on ctsMediaStreamServer.cpp
+*/
+// cpp headers
+#include <memory>
+#include <vector>
+#include <algorithm>
+// os headers
+#include <Windows.h>
+#include <WinSock2.h>
+// ctl headers
+#include <ctSockaddr.hpp>
+// project headers
+#include "ctsConfig.h"
+#include "ctsSocket.h"
+#include "ctsIOTask.hpp"
+#include "ctsWinsockLayer.h"
+#include "ctsMediaUploadServer.h"
+#include "ctsMediaUploadServerConnectedSocket.h"
+#include "ctsMediaUploadServerListeningSocket.h"
+#include "ctsMediaUploadProtocol.hpp"
+// wil headers always included last
+#include <wil/stl.h>
+#include <wil/resource.h>
+
+namespace ctsTraffic
+{
+    void ctsMediaUploadServerListener(const std::weak_ptr<ctsSocket>& weakSocket) noexcept try
+    {
+        ctsMediaUploadServerImpl::InitOnce();
+        ctsMediaUploadServerImpl::AcceptSocket(weakSocket);
+    }
+    catch (...)
+    {
+        const auto error = ctsConfig::PrintThrownException();
+        if (const auto sharedSocket = weakSocket.lock())
+        {
+            sharedSocket->CompleteState(error);
+        }
+    }
+
+    void ctsMediaUploadServerIo(const std::weak_ptr<ctsSocket>& weakSocket) noexcept
+    {
+        const auto sharedSocket(weakSocket.lock());
+        if (!sharedSocket)
+        {
+            return;
+        }
+
+        const auto lockedSocket = sharedSocket->AcquireSocketLock();
+        const auto lockedPattern = lockedSocket.GetPattern();
+        if (!lockedPattern)
+        {
+            return;
+        }
+
+        ctsTask nextTask;
+        try
+        {
+            ctsMediaUploadServerImpl::InitOnce();
+
+            do
+            {
+                nextTask = lockedPattern->InitiateIo();
+                if (nextTask.m_ioAction != ctsTaskAction::None)
+                {
+                    ctsMediaUploadServerImpl::ScheduleIo(weakSocket, nextTask);
+                }
+            } while (nextTask.m_ioAction != ctsTaskAction::None);
+        }
+        catch (...)
+        {
+            const auto error = ctsConfig::PrintThrownException();
+            if (nextTask.m_ioAction != ctsTaskAction::None)
+            {
+                lockedPattern->CompleteIo(nextTask, 0, error);
+                if (0 == sharedSocket->GetPendedIoCount())
+                {
+                    sharedSocket->CompleteState(error);
+                }
+            }
+        }
+    }
+
+    void ctsMediaUploadServerClose(const std::weak_ptr<ctsSocket>& weakSocket) noexcept try
+    {
+        ctsMediaUploadServerImpl::InitOnce();
+
+        if (const auto sharedSocket = weakSocket.lock())
+        {
+            ctsMediaUploadServerImpl::RemoveSocket(sharedSocket->GetRemoteSockaddr());
+        }
+    }
+    catch (...)
+    {
+    }
+
+    namespace ctsMediaUploadServerImpl
+    {
+        static wsIOResult ConnectedSocketIo(_In_ ctsMediaUploadServerConnectedSocket* connectedSocket) noexcept;
+
+        static std::vector<std::unique_ptr<ctsMediaUploadServerListeningSocket>> g_listeningSockets;
+
+        static wil::critical_section g_socketVectorGuard{ ctsConfig::ctsConfigSettings::c_CriticalSectionSpinlock };
+
+        _Guarded_by_(g_socketVectorGuard) static std::vector<std::shared_ptr<ctsMediaUploadServerConnectedSocket>> g_connectedSockets;
+
+        _Guarded_by_(g_socketVectorGuard) static std::vector<std::weak_ptr<ctsSocket>> g_acceptingSockets;
+
+        _Guarded_by_(g_socketVectorGuard) static std::vector<std::pair<SOCKET, ctl::ctSockaddr>> g_awaitingEndpoints;
+
+        static INIT_ONCE g_initImpl = INIT_ONCE_STATIC_INIT;
+
+        static BOOL CALLBACK InitOnceImpl(PINIT_ONCE, PVOID, PVOID*) noexcept try
+        {
+            for (const auto& addr : ctsConfig::g_configSettings->ListenAddresses)
+            {
+                wil::unique_socket listening(ctsConfig::CreateSocket(addr.family(), SOCK_DGRAM, IPPROTO_UDP, ctsConfig::g_configSettings->SocketFlags));
+
+                auto error = ctsConfig::SetPreBindOptions(listening.get(), addr);
+                if (error != NO_ERROR)
+                {
+                    THROW_WIN32_MSG(error, "SetPreBindOptions (ctsMediaUploadServer)");
+                }
+
+                if (SOCKET_ERROR == bind(listening.get(), addr.sockaddr(), addr.length()))
+                {
+                    error = WSAGetLastError();
+                    char addrBuffer[ctl::ctSockaddr::FixedStringLength]{};
+                    addr.writeAddress(addrBuffer);
+                    THROW_WIN32_MSG(error, "bind %hs (ctsMediaUploadServer)", addrBuffer);
+                }
+
+                const SOCKET listeningSocketToPrint(listening.get());
+                g_listeningSockets.emplace_back(
+                    std::make_unique<ctsMediaUploadServerListeningSocket>(std::move(listening), addr));
+                PRINT_DEBUG_INFO(
+                    L"\t\tctsMediaUploadServer - Receiving datagrams on %ws (%Iu)\n",
+                    addr.writeCompleteAddress().c_str(),
+                    listeningSocketToPrint);
+            }
+
+            if (g_listeningSockets.empty())
+            {
+                throw std::exception("ctsMediaUploadServer invoked with no listening addresses specified");
+            }
+
+            for (const auto& listener : g_listeningSockets)
+            {
+                listener->InitiateRecv();
+            }
+
+            return TRUE;
+        }
+        catch (...)
+        {
+            ctsConfig::PrintThrownException();
+            return FALSE;
+        }
+
+        void InitOnce()
+        {
+            if (!InitOnceExecuteOnce(&g_initImpl, InitOnceImpl, nullptr, nullptr))
+            {
+                throw std::runtime_error("ctsMediaUploadServerListener could not be instantiated");
+            }
+        }
+
+        void ScheduleIo(const std::weak_ptr<ctsSocket>& weakSocket, const ctsTask& task)
+        {
+            auto sharedSocket = weakSocket.lock();
+            if (!sharedSocket)
+            {
+                THROW_WIN32_MSG(WSAECONNABORTED, "ctsSocket already freed");
+            }
+
+            std::shared_ptr<ctsMediaUploadServerConnectedSocket> sharedConnectedSocket;
+            {
+                const auto lockConnectedObject = g_socketVectorGuard.lock();
+
+                const auto foundSocket = std::ranges::find_if(
+                    g_connectedSockets,
+                    [&sharedSocket](const std::shared_ptr<ctsMediaUploadServerConnectedSocket>& connectedSocket) noexcept {
+                        return sharedSocket->GetRemoteSockaddr() == connectedSocket->GetRemoteAddress();
+                    }
+                );
+
+                if (foundSocket == std::end(g_connectedSockets))
+                {
+                    ctsConfig::PrintErrorInfo(
+                        L"ctsMediaUploadServer - failed to find the socket with remote address %ws in our connected socket list to continue sending datagrams",
+                        sharedSocket->GetRemoteSockaddr().writeCompleteAddress().c_str());
+                    THROW_WIN32_MSG(ERROR_INVALID_DATA, "ctsSocket was not found in the connected sockets to continue sending datagrams");
+                }
+
+                sharedConnectedSocket = *foundSocket;
+            }
+            sharedConnectedSocket->ScheduleTask(task);
+        }
+
+        void AcceptSocket(const std::weak_ptr<ctsSocket>& weakSocket)
+        {
+            if (const auto sharedSocket = weakSocket.lock())
+            {
+                const auto lockAwaitingObject = g_socketVectorGuard.lock();
+
+                if (g_awaitingEndpoints.empty())
+                {
+                    g_acceptingSockets.push_back(weakSocket);
+                }
+                else
+                {
+                    auto waitingEndpoint = g_awaitingEndpoints.rbegin();
+
+                    const auto existingSocket = std::ranges::find_if(
+                        g_connectedSockets,
+                        [&](const std::shared_ptr<ctsMediaUploadServerConnectedSocket>& connectedSocket) noexcept {
+                            return waitingEndpoint->second == connectedSocket->GetRemoteAddress();
+                        });
+
+                    if (existingSocket != std::end(g_connectedSockets))
+                    {
+                        ctsConfig::g_configSettings->UdpStatusDetails.m_duplicateFrames.Increment();
+                        PRINT_DEBUG_INFO(L"\t\tctsMediaUploadServer::accept_socket - socket with remote address %ws asked to be Started but was already established",
+                            waitingEndpoint->second.writeCompleteAddress().c_str());
+                        return;
+                    }
+
+                    g_connectedSockets.emplace_back(
+                        std::make_shared<ctsMediaUploadServerConnectedSocket>(
+                            weakSocket,
+                            waitingEndpoint->first,
+                            waitingEndpoint->second,
+                            ConnectedSocketIo));
+
+                    PRINT_DEBUG_INFO(L"\t\tctsMediaUploadServer::accept_socket - socket with remote address %ws added to connected_sockets",
+                        waitingEndpoint->second.writeCompleteAddress().c_str());
+
+                    const auto foundSocket = std::ranges::find_if(
+                        g_listeningSockets,
+                        [&waitingEndpoint](const std::unique_ptr<ctsMediaUploadServerListeningSocket>& listener) noexcept {
+                            return listener->GetSocket() == waitingEndpoint->first;
+                        });
+                    FAIL_FAST_IF_MSG(
+                        foundSocket == g_listeningSockets.end(),
+                        "Could not find the socket (%Iu) in the waiting_endpoint from our listening sockets (%p)",
+                        waitingEndpoint->first, &g_listeningSockets);
+
+                    ctsConfig::SetPostConnectOptions(sharedSocket->AcquireSocketLock().GetSocket(), waitingEndpoint->second);
+
+                    sharedSocket->SetLocalSockaddr((*foundSocket)->GetListeningAddress());
+                    sharedSocket->SetRemoteSockaddr(waitingEndpoint->second);
+                    sharedSocket->CompleteState(NO_ERROR);
+
+                    ctsConfig::PrintNewConnection(sharedSocket->GetLocalSockaddr(), sharedSocket->GetRemoteSockaddr());
+                    g_awaitingEndpoints.pop_back();
+                }
+            }
+        }
+
+        void RemoveSocket(const ctl::ctSockaddr& targetAddr)
+        {
+            const auto lockConnectedObject = g_socketVectorGuard.lock();
+
+            const auto foundSocket = std::ranges::find_if(
+                g_connectedSockets,
+                [&targetAddr](const std::shared_ptr<ctsMediaUploadServerConnectedSocket>& connectedSocket) noexcept {
+                    return targetAddr == connectedSocket->GetRemoteAddress();
+                });
+
+            if (foundSocket != std::end(g_connectedSockets))
+            {
+                g_connectedSockets.erase(foundSocket);
+            }
+        }
+
+        void Start(SOCKET socket, const ctl::ctSockaddr& localAddr, const ctl::ctSockaddr& targetAddr)
+        {
+            const auto lockAwaitingObject = g_socketVectorGuard.lock();
+
+            const auto existingSocket = std::ranges::find_if(
+                g_connectedSockets,
+                [&targetAddr](const std::shared_ptr<ctsMediaUploadServerConnectedSocket>& connectedSocket) noexcept {
+                    return targetAddr == connectedSocket->GetRemoteAddress();
+                });
+            if (existingSocket != std::end(g_connectedSockets))
+            {
+                ctsConfig::g_configSettings->UdpStatusDetails.m_duplicateFrames.Increment();
+                PRINT_DEBUG_INFO(L"\t\tctsMediaUploadServer::start - socket with remote address %ws asked to be Started but was already in connected_sockets",
+                    targetAddr.writeCompleteAddress().c_str());
+                return;
+            }
+
+            const auto awaitingEndpoint = std::ranges::find_if(
+                g_awaitingEndpoints,
+                [&targetAddr](const std::pair<SOCKET, ctl::ctSockaddr>& endpoint) noexcept {
+                    return targetAddr == endpoint.second;
+                });
+            if (awaitingEndpoint != std::end(g_awaitingEndpoints))
+            {
+                ctsConfig::g_configSettings->UdpStatusDetails.m_duplicateFrames.Increment();
+                PRINT_DEBUG_INFO(L"\t\tctsMediaUploadServer::start - socket with remote address %ws asked to be Started but was already in awaiting endpoints",
+                    targetAddr.writeCompleteAddress().c_str());
+                return;
+            }
+
+            auto addToAwaiting = true;
+            while (!g_acceptingSockets.empty())
+            {
+                auto weakInstance = *g_acceptingSockets.rbegin();
+                if (const auto sharedInstance = weakInstance.lock())
+                {
+                    g_connectedSockets.emplace_back(
+                        std::make_shared<ctsMediaUploadServerConnectedSocket>(weakInstance, socket, targetAddr, ConnectedSocketIo));
+
+                    PRINT_DEBUG_INFO(L"\t\tctsMediaUploadServer::start - socket with remote address %ws added to connected_sockets",
+                        targetAddr.writeCompleteAddress().c_str());
+
+                    addToAwaiting = false;
+                    g_acceptingSockets.pop_back();
+
+                    ctsConfig::SetPostConnectOptions(socket, targetAddr);
+
+                    sharedInstance->SetLocalSockaddr(localAddr);
+                    sharedInstance->SetRemoteSockaddr(targetAddr);
+                    sharedInstance->CompleteState(NO_ERROR);
+
+                    ctsConfig::PrintNewConnection(localAddr, targetAddr);
+                    break;
+                }
+            }
+
+            if (addToAwaiting)
+            {
+                PRINT_DEBUG_INFO(L"\t\tctsMediaUploadServer::start - socket with remote address %ws added to awaiting_endpoints",
+                    targetAddr.writeCompleteAddress().c_str());
+
+                g_awaitingEndpoints.emplace_back(socket, targetAddr);
+            }
+        }
+
+        void DispatchDatagram(SOCKET listeningSocket, const ctl::ctSockaddr& remoteAddr, const char* buffer, uint32_t length)
+        {
+            const auto lockAwaitingObject = g_socketVectorGuard.lock();
+
+            const auto existingSocket = std::ranges::find_if(
+                g_connectedSockets,
+                [&remoteAddr](const std::shared_ptr<ctsMediaUploadServerConnectedSocket>& connectedSocket) noexcept {
+                    return remoteAddr == connectedSocket->GetRemoteAddress();
+                });
+
+            if (existingSocket != std::end(g_connectedSockets))
+            {
+                (*existingSocket)->EnqueueReceivedDatagram(buffer, length);
+                return;
+            }
+
+            // If no connected socket exists yet, queue the endpoint so Start/Accept can match later
+            g_awaitingEndpoints.emplace_back(listeningSocket, remoteAddr);
+        }
+
+        wsIOResult ConnectedSocketIo(_In_ ctsMediaUploadServerConnectedSocket* connectedSocket) noexcept
+        {
+            const SOCKET socket = connectedSocket->GetSendingSocket();
+            if (INVALID_SOCKET == socket)
+            {
+                return wsIOResult(WSA_OPERATION_ABORTED);
+            }
+
+            const ctl::ctSockaddr& remoteAddr(connectedSocket->GetRemoteAddress());
+            const ctsTask nextTask = connectedSocket->GetNextTask();
+
+            wsIOResult returnResults;
+            if (ctsTask::BufferType::UdpConnectionId == nextTask.m_bufferType)
+            {
+                WSABUF wsaBuffer;
+                wsaBuffer.buf = nextTask.m_buffer;
+                wsaBuffer.len = nextTask.m_bufferLength;
+
+                const auto sendResult = WSASendTo(
+                    socket,
+                    &wsaBuffer,
+                    1,
+                    &returnResults.m_bytesTransferred,
+                    0,
+                    remoteAddr.sockaddr(),
+                    remoteAddr.length(),
+                    nullptr,
+                    nullptr);
+
+                if (SOCKET_ERROR == sendResult)
+                {
+                    const auto error = WSAGetLastError();
+                    ctsConfig::PrintErrorInfo(
+                        L"WSASendTo(%Iu, %ws) for the Connection-ID failed [%d]",
+                        socket,
+                        remoteAddr.writeCompleteAddress().c_str(),
+                        error);
+                    return wsIOResult(error);
+                }
+            }
+            else
+            {
+                const auto sequenceNumber = connectedSocket->IncrementSequence();
+                ctsMediaUploadSendRequests sendingRequests(
+                    nextTask.m_bufferLength,
+                    sequenceNumber,
+                    nextTask.m_buffer);
+                for (auto& sendRequest : sendingRequests)
+                {
+                    DWORD bytesSent{};
+                    const auto sendResult = WSASendTo(
+                        socket,
+                        sendRequest.data(),
+                        static_cast<DWORD>(sendRequest.size()),
+                        &bytesSent,
+                        0,
+                        remoteAddr.sockaddr(),
+                        remoteAddr.length(),
+                        nullptr,
+                        nullptr);
+                    if (SOCKET_ERROR == sendResult)
+                    {
+                        const auto error = WSAGetLastError();
+                        if (WSAEMSGSIZE == error)
+                        {
+                            uint32_t bytesRequested = 0;
+                            for (const auto& wsaBuffer : sendRequest)
+                            {
+                                bytesRequested += wsaBuffer.len;
+                            }
+                            ctsConfig::PrintErrorInfo(
+                                L"WSASendTo(%Iu, seq %lld, %ws) failed with WSAEMSGSIZE : attempted to send datagram of size %u bytes",
+                                socket,
+                                sequenceNumber,
+                                remoteAddr.writeCompleteAddress().c_str(),
+                                bytesRequested);
+                        }
+                        else
+                        {
+                            ctsConfig::PrintErrorInfo(
+                                L"WSASendTo(%Iu, seq %lld, %ws) failed [%d]",
+                                socket,
+                                sequenceNumber,
+                                remoteAddr.writeCompleteAddress().c_str(),
+                                error);
+                        }
+                        return wsIOResult(error);
+                    }
+
+                    returnResults.m_bytesTransferred += bytesSent;
+                    PRINT_DEBUG_INFO(
+                        L"\t\tctsMediaUploadServer sending seq number %lld (%u sent-bytes, %u frame-bytes)\n",
+                        sequenceNumber, bytesSent, returnResults.m_bytesTransferred);
+                }
+            }
+
+            return returnResults;
+        }
+    }
+} 

--- a/ctsTraffic/ctsMediaUploadServer.h
+++ b/ctsTraffic/ctsMediaUploadServer.h
@@ -1,0 +1,28 @@
+/*
+Upload server header - based on ctsMediaStreamServer.h
+*/
+#pragma once
+
+// cpp headers
+#include <memory>
+// ctl headers
+#include <ctSockaddr.hpp>
+// project headers
+#include "ctsSocket.h"
+#include "ctsIOTask.hpp"
+
+namespace ctsTraffic { namespace ctsMediaUploadServerImpl
+    {
+        void InitOnce();
+        void ScheduleIo(const std::weak_ptr<ctsSocket>& weakSocket, const ctsTask& task);
+        void AcceptSocket(const std::weak_ptr<ctsSocket>& weakSocket);
+        void RemoveSocket(const ctl::ctSockaddr& targetAddr);
+        void Start(SOCKET socket, const ctl::ctSockaddr& localAddr, const ctl::ctSockaddr& targetAddr);
+        // Dispatch an incoming datagram to the server implementation
+        void DispatchDatagram(SOCKET listeningSocket, const ctl::ctSockaddr& remoteAddr, const char* buffer, uint32_t length);
+    }
+
+    void ctsMediaUploadServerListener(const std::weak_ptr<ctsSocket>& weakSocket) noexcept;
+    void ctsMediaUploadServerIo(const std::weak_ptr<ctsSocket>& weakSocket) noexcept;
+    void ctsMediaUploadServerClose(const std::weak_ptr<ctsSocket>& weakSocket) noexcept;
+}

--- a/ctsTraffic/ctsMediaUploadServerConnectedSocket.cpp
+++ b/ctsTraffic/ctsMediaUploadServerConnectedSocket.cpp
@@ -1,0 +1,219 @@
+// parent header
+#include "ctsMediaUploadServerConnectedSocket.h"
+// cpp headers
+#include <memory>
+#include <functional>
+#include <utility>
+#include <deque>
+#include <vector>
+// os headers
+#include <Windows.h>
+#include <WinSock2.h>
+// ctl headers
+#include <ctSockaddr.hpp>
+#include <ctString.hpp>
+#include <ctTimer.hpp>
+// project headers
+#include "ctsWinsockLayer.h"
+
+using namespace ctl;
+
+namespace ctsTraffic
+{
+ctsMediaUploadServerConnectedSocket::ctsMediaUploadServerConnectedSocket(
+    std::weak_ptr<ctsSocket> weakSocket,
+    SOCKET sendingSocket,
+    ctSockaddr remoteAddr,
+    ctsMediaUploadConnectedSocketIoFunctor ioFunctor) :
+    m_weakSocket(std::move(weakSocket)),
+    m_ioFunctor(std::move(ioFunctor)),
+    m_sendingSocket(sendingSocket),
+    m_remoteAddr(std::move(remoteAddr)),
+    m_connectTime(ctTimer::snap_qpc_as_msec())
+{
+    m_taskTimer.reset(CreateThreadpoolTimer(MediaUploadTimerCallback, this, ctsConfig::g_configSettings->pTpEnvironment));
+    THROW_LAST_ERROR_IF(!m_taskTimer);
+}
+
+ctsMediaUploadServerConnectedSocket::~ctsMediaUploadServerConnectedSocket() noexcept
+{
+    m_taskTimer.reset();
+}
+
+void ctsMediaUploadServerConnectedSocket::ScheduleTask(const ctsTask& task) noexcept
+{
+    if (const auto sharedSocket = m_weakSocket.lock())
+    {
+        const auto lock = m_objectGuard.lock();
+        _Analysis_assume_lock_acquired_(m_objectGuard);
+        if (task.m_timeOffsetMilliseconds < 2)
+        {
+            m_nextTask = task;
+            MediaUploadTimerCallback(nullptr, this, nullptr);
+        }
+        else
+        {
+            FILETIME ftDueTime{ctTimer::convert_ms_to_relative_filetime(task.m_timeOffsetMilliseconds)};
+            m_nextTask = task;
+            SetThreadpoolTimer(m_taskTimer.get(), &ftDueTime, 0, 0);
+        }
+        _Analysis_assume_lock_released_(m_objectGuard);
+    }
+}
+
+void ctsMediaUploadServerConnectedSocket::CompleteState(uint32_t errorCode) const noexcept
+{
+    if (const auto sharedSocket = m_weakSocket.lock())
+    {
+        sharedSocket->CompleteState(errorCode);
+    }
+}
+
+void ctsMediaUploadServerConnectedSocket::EnqueueReceivedDatagram(const char* buffer, uint32_t length) noexcept
+{
+    try
+    {
+        const auto lock = m_objectGuard.lock();
+        std::vector<char> v;
+        v.assign(buffer, buffer + length);
+        m_recvQueue.emplace_back(std::move(v));
+        // kick the timer so the connected socket will process pending Recv tasks
+        SetThreadpoolTimer(m_taskTimer.get(), nullptr, 0, 0);
+    }
+    catch (...)
+    {
+        ctsConfig::PrintThrownException();
+    }
+}
+
+VOID CALLBACK ctsMediaUploadServerConnectedSocket::MediaUploadTimerCallback(PTP_CALLBACK_INSTANCE, PVOID context, PTP_TIMER) noexcept
+{
+    auto* thisPtr = static_cast<ctsMediaUploadServerConnectedSocket*>(context);
+
+    const auto sharedSocket = thisPtr->m_weakSocket.lock();
+    if (!sharedSocket)
+    {
+        return;
+    }
+
+    const auto lockedSocket = sharedSocket->AcquireSocketLock();
+    const auto lockedPattern = lockedSocket.GetPattern();
+    if (!lockedPattern)
+    {
+        return;
+    }
+
+    const auto lock = thisPtr->m_objectGuard.lock();
+    _Analysis_assume_lock_acquired_(thisPtr->m_objectGuard);
+
+    // service Recv tasks first using any queued received datagrams
+    ctsTask currentTask = thisPtr->m_nextTask;
+    auto status = ctsIoStatus::ContinueIo;
+
+    if (currentTask.m_ioAction == ctsTaskAction::Recv)
+    {
+        std::vector<char> datagram;
+        {
+            const auto recvLock = thisPtr->m_objectGuard.lock();
+            _Analysis_assume_lock_acquired_(thisPtr->m_objectGuard);
+            if (!thisPtr->m_recvQueue.empty())
+            {
+                datagram = std::move(thisPtr->m_recvQueue.front());
+                thisPtr->m_recvQueue.pop_front();
+            }
+        }
+
+        if (!datagram.empty())
+        {
+            status = lockedPattern->CompleteIo(currentTask, static_cast<uint32_t>(datagram.size()), 0);
+        }
+    }
+
+    // if still continuing, handle send requests as before
+    wsIOResult sendResults{};
+    if (status == ctsIoStatus::ContinueIo)
+    {
+        sendResults = thisPtr->m_ioFunctor(thisPtr);
+        status = lockedPattern->CompleteIo(
+            thisPtr->m_nextTask,
+            sendResults.m_bytesTransferred,
+            sendResults.m_errorCode);
+
+        while (ctsIoStatus::ContinueIo == status && thisPtr->m_nextTask.m_ioAction != ctsTaskAction::None)
+        {
+            currentTask = lockedPattern->InitiateIo();
+
+            switch (currentTask.m_ioAction)
+            {
+                case ctsTaskAction::Send:
+                    thisPtr->m_nextTask = currentTask;
+                    if (thisPtr->m_nextTask.m_timeOffsetMilliseconds < 2)
+                    {
+                        sendResults = thisPtr->m_ioFunctor(thisPtr);
+                        status = lockedPattern->CompleteIo(
+                            thisPtr->m_nextTask,
+                            sendResults.m_bytesTransferred,
+                            sendResults.m_errorCode);
+                    }
+                    else
+                    {
+                        thisPtr->ScheduleTask(thisPtr->m_nextTask);
+                    }
+                    break;
+
+                case ctsTaskAction::None:
+                    break;
+
+                case ctsTaskAction::Recv:
+                    // Attempt to satisfy Recv from queued datagrams
+                    {
+                        std::vector<char> datagram;
+                        const auto lockRecv = thisPtr->m_objectGuard.lock();
+                        _Analysis_assume_lock_acquired_(thisPtr->m_objectGuard);
+                        if (!thisPtr->m_recvQueue.empty())
+                        {
+                            datagram = std::move(thisPtr->m_recvQueue.front());
+                            thisPtr->m_recvQueue.pop_front();
+                        }
+                        if (!datagram.empty())
+                        {
+                            status = lockedPattern->CompleteIo(currentTask, static_cast<uint32_t>(datagram.size()), 0);
+                        }
+                        else
+                        {
+                            thisPtr->m_nextTask = currentTask;
+                        }
+                    }
+                    break;
+
+                default:
+                    FAIL_FAST_MSG(
+                        "Unexpected task action returned from initiate_io - %d (dt %p ctsTraffic::ctsIOTask)",
+                        currentTask.m_ioAction, &currentTask);
+            }
+        }
+    }
+
+    if (ctsIoStatus::FailedIo == status)
+    {
+        uint32_t returnedStatus = sendResults.m_errorCode;
+        if (0 == returnedStatus)
+        {
+            returnedStatus = WSAECONNABORTED;
+        }
+
+        ctsConfig::PrintErrorInfo(
+            L"MediaUpload Server socket (%ws) was indicated Failed IO from the protocol - aborting this stream",
+            thisPtr->m_remoteAddr.writeCompleteAddress().c_str());
+        thisPtr->CompleteState(returnedStatus);
+    }
+    else if (ctsIoStatus::CompletedIo == status)
+    {
+        PRINT_DEBUG_INFO(
+            L"\t\tctsMediaUploadServerConnectedSocket socket (%ws) has completed its stream - closing this 'connection'\n",
+            thisPtr->m_remoteAddr.writeCompleteAddress().c_str());
+        thisPtr->CompleteState(sendResults.m_errorCode);
+    }
+    _Analysis_assume_lock_released_(thisPtr->m_objectGuard);
+}
+} // namespace

--- a/ctsTraffic/ctsMediaUploadServerConnectedSocket.h
+++ b/ctsTraffic/ctsMediaUploadServerConnectedSocket.h
@@ -1,0 +1,95 @@
+/*
+Upload connected socket header
+*/
+#pragma once
+
+// cpp headers
+#include <memory>
+// os headers
+#include <Windows.h>
+#include <WinSock2.h>
+// ctl headers
+#include <ctSockaddr.hpp>
+// project headers
+#include "ctsIOTask.hpp"
+#include "ctsSocket.h"
+#include "ctsWinsockLayer.h"
+// wil headers always included last
+#include <wil/resource.h>
+#include <deque>
+#include <vector>
+
+namespace ctsTraffic
+{
+class ctsMediaUploadServerConnectedSocket;
+using ctsMediaUploadConnectedSocketIoFunctor = std::function<wsIOResult (ctsMediaUploadServerConnectedSocket*)>;
+
+class ctsMediaUploadServerConnectedSocket
+{
+private:
+    mutable wil::critical_section m_objectGuard{ctsConfig::ctsConfigSettings::c_CriticalSectionSpinlock};
+    _Guarded_by_(m_objectGuard) ctsTask m_nextTask;
+
+    wil::unique_threadpool_timer m_taskTimer{};
+
+    const std::weak_ptr<ctsSocket> m_weakSocket;
+    const ctsMediaUploadConnectedSocketIoFunctor m_ioFunctor;
+    const SOCKET m_sendingSocket;
+    const ctl::ctSockaddr m_remoteAddr;
+
+    int64_t m_sequenceNumber = 0LL;
+    const int64_t m_connectTime = 0LL;
+    // queued datagrams received from the listening socket to satisfy Recv tasks
+    std::deque<std::vector<char>> m_recvQueue;
+
+public:
+    ctsMediaUploadServerConnectedSocket(
+        std::weak_ptr<ctsSocket> weakSocket,
+        SOCKET sendingSocket,
+        ctl::ctSockaddr remoteAddr,
+        ctsMediaUploadConnectedSocketIoFunctor ioFunctor);
+
+    ~ctsMediaUploadServerConnectedSocket() noexcept;
+
+    const ctl::ctSockaddr& GetRemoteAddress() const noexcept
+    {
+        return m_remoteAddr;
+    }
+
+    SOCKET GetSendingSocket() const noexcept
+    {
+        return m_sendingSocket;
+    }
+
+    int64_t GetStartTime() const noexcept
+    {
+        return m_connectTime;
+    }
+
+    ctsTask GetNextTask() const noexcept
+    {
+        const auto lock = m_objectGuard.lock();
+        return m_nextTask;
+    }
+
+    int64_t IncrementSequence() noexcept
+    {
+        return InterlockedIncrement64(&m_sequenceNumber);
+    }
+
+    void ScheduleTask(const ctsTask& task) noexcept;
+
+    void CompleteState(uint32_t errorCode) const noexcept;
+
+    // Called by the listening socket when a datagram is received from this remote address
+    void EnqueueReceivedDatagram(const char* buffer, uint32_t length) noexcept;
+
+    ctsMediaUploadServerConnectedSocket(const ctsMediaUploadServerConnectedSocket&) = delete;
+    ctsMediaUploadServerConnectedSocket& operator=(const ctsMediaUploadServerConnectedSocket&) = delete;
+    ctsMediaUploadServerConnectedSocket(ctsMediaUploadServerConnectedSocket&&) = delete;
+    ctsMediaUploadServerConnectedSocket& operator=(ctsMediaUploadServerConnectedSocket&&) = delete;
+
+private:
+    static VOID CALLBACK MediaUploadTimerCallback(PTP_CALLBACK_INSTANCE, PVOID context, PTP_TIMER) noexcept;
+};
+}

--- a/ctsTraffic/ctsMediaUploadServerListeningSocket.cpp
+++ b/ctsTraffic/ctsMediaUploadServerListeningSocket.cpp
@@ -1,0 +1,225 @@
+// cpp headers
+#include <exception>
+#include <memory>
+#include <utility>
+// os headers
+#include <Windows.h>
+#include <WinSock2.h>
+// ctl headers
+#include <ctThreadIocp.hpp>
+#include <ctSockaddr.hpp>
+// project headers
+#include "ctsMediaUploadServerListeningSocket.h"
+#include "ctsMediaUploadServer.h"
+#include "ctsMediaUploadProtocol.hpp"
+#include "ctsConfig.h"
+// wil headers always included last
+#include <wil/stl.h>
+#include <wil/resource.h>
+
+namespace ctsTraffic
+{
+ctsMediaUploadServerListeningSocket::ctsMediaUploadServerListeningSocket(wil::unique_socket&& listeningSocket, ctl::ctSockaddr listeningAddr) :
+    m_threadIocp(std::make_shared<ctl::ctThreadIocp>(listeningSocket.get(), ctsConfig::g_configSettings->pTpEnvironment)),
+    m_listeningSocket(std::move(listeningSocket)),
+    m_listeningAddr(std::move(listeningAddr))
+{
+    FAIL_FAST_IF_MSG(
+        !!(ctsConfig::g_configSettings->Options & ctsConfig::OptionType::HandleInlineIocp),
+        "ctsMediaUploadServer sockets must not have HANDLE_INLINE_IOCP set on its datagram sockets");
+}
+
+ctsMediaUploadServerListeningSocket::~ctsMediaUploadServerListeningSocket() noexcept
+{
+    {
+        const auto lock = m_listeningSocketLock.lock();
+        m_listeningSocket.reset();
+    }
+    m_threadIocp.reset();
+}
+
+SOCKET ctsMediaUploadServerListeningSocket::GetSocket() const noexcept
+{
+    const auto lock = m_listeningSocketLock.lock();
+    return m_listeningSocket.get();
+}
+
+ctl::ctSockaddr ctsMediaUploadServerListeningSocket::GetListeningAddress() const noexcept
+{
+    return m_listeningAddr;
+}
+
+void ctsMediaUploadServerListeningSocket::InitiateRecv() noexcept
+{
+    int error = SOCKET_ERROR;
+    uint32_t failureCounter = 0;
+    while (error != NO_ERROR)
+    {
+        try
+        {
+            const auto lock = m_listeningSocketLock.lock();
+            if (m_listeningSocket)
+            {
+                WSABUF wsaBuffer{};
+                wsaBuffer.buf = m_recvBuffer.data();
+                wsaBuffer.len = static_cast<ULONG>(m_recvBuffer.size());
+                ::ZeroMemory(m_recvBuffer.data(), m_recvBuffer.size());
+
+                m_recvFlags = 0;
+                m_remoteAddr.reset(m_remoteAddr.family(), ctl::ctSockaddr::AddressType::Any);
+                m_remoteAddrLen = m_remoteAddr.length();
+                OVERLAPPED* pOverlapped = m_threadIocp->new_request(
+                    [this](OVERLAPPED* pCallbackOverlapped) noexcept {
+                        RecvCompletion(pCallbackOverlapped);
+                    });
+
+                error = WSARecvFrom(
+                    m_listeningSocket.get(),
+                    &wsaBuffer,
+                    1,
+                    nullptr,
+                    &m_recvFlags,
+                    m_remoteAddr.sockaddr(),
+                    &m_remoteAddrLen,
+                    pOverlapped,
+                    nullptr);
+                if (SOCKET_ERROR == error)
+                {
+                    error = WSAGetLastError();
+                    if (WSA_IO_PENDING == error)
+                    {
+                        error = NO_ERROR;
+                    }
+                    else
+                    {
+                        m_threadIocp->cancel_request(pOverlapped);
+                        if (WSAECONNRESET == error)
+                        {
+                        }
+                        else
+                        {
+                            ctsConfig::PrintErrorInfo(
+                                L"WSARecvFrom failed (SOCKET %Iu) with error (%d)",
+                                m_listeningSocket.get(), error);
+                        }
+                    }
+                }
+                else
+                {
+                    error = NO_ERROR;
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+        catch (...)
+        {
+            error = static_cast<int>(ctsConfig::PrintThrownException());
+        }
+
+        if (error != NO_ERROR && error != WSAECONNRESET)
+        {
+            ctsConfig::g_configSettings->UdpStatusDetails.m_errorFrames.Increment();
+            ++failureCounter;
+
+            ctsConfig::PrintErrorInfo(
+                L"MediaUpload Server : WSARecvFrom failed (%d) %u times in a row trying to get another recv posted",
+                error, failureCounter);
+
+            FAIL_FAST_IF_MSG(
+                0 == failureCounter % 10,
+                "ctsMediaUploadServer has failed to post another recv - it cannot accept any more client connections");
+
+            Sleep(10);
+        }
+    }
+}
+
+void ctsMediaUploadServerListeningSocket::RecvCompletion(OVERLAPPED* pOverlapped) noexcept
+{
+    std::function<void()> pimplOperation(nullptr);
+
+    try
+    {
+        {
+            const auto lock = m_listeningSocketLock.lock();
+            if (!m_listeningSocket)
+            {
+                return;
+            }
+
+            DWORD bytesReceived{};
+            if (!WSAGetOverlappedResult(m_listeningSocket.get(), pOverlapped, &bytesReceived, FALSE, &m_recvFlags))
+            {
+                if (WSAECONNRESET == WSAGetLastError())
+                {
+                    if (!m_priorFailureWasConnectionReset)
+                    {
+                        ctsConfig::PrintErrorInfo(L"ctsMediaUploadServer - WSARecvFrom failed as a prior WSASendTo from this socket silently failed with port unreachable");
+                    }
+                    m_priorFailureWasConnectionReset = true;
+                }
+                else
+                {
+                    ctsConfig::PrintErrorInfo(
+                        L"ctsMediaUploadServer - WSARecvFrom failed [%d]", WSAGetLastError());
+                    ctsConfig::g_configSettings->UdpStatusDetails.m_errorFrames.Increment();
+                    m_priorFailureWasConnectionReset = false;
+                }
+            }
+            else
+            {
+                m_priorFailureWasConnectionReset = false;
+                // try to parse as a control message first
+                bool parsedAsControl = false;
+                try
+                {
+                    const ctsMediaUploadMessage message(ctsMediaUploadMessage::Extract(m_recvBuffer.data(), bytesReceived));
+                    switch (message.m_action)
+                    {
+                        case MediaUploadAction::START:
+                            PRINT_DEBUG_INFO(
+                                L"\t\tctsMediaUploadServer - processing START from %ws\n",
+                                m_remoteAddr.writeCompleteAddress().c_str());
+    #ifndef TESTING_IGNORE_START
+                            pimplOperation = [this] {
+                                ctsMediaUploadServerImpl::Start(m_listeningSocket.get(), m_listeningAddr, m_remoteAddr);
+                            };
+    #endif
+                            parsedAsControl = true;
+                            break;
+
+                        default:
+                            // unknown control; fall through to treat as data
+                            parsedAsControl = false;
+                            break;
+                    }
+                }
+                catch (...) // not a control message: treat as data
+                {
+                    parsedAsControl = false;
+                }
+
+                if (!parsedAsControl)
+                {
+                    // dispatch datagram to server impl to either route to a connected socket or queue
+                    ctsMediaUploadServerImpl::DispatchDatagram(m_listeningSocket.get(), m_remoteAddr, m_recvBuffer.data(), static_cast<uint32_t>(bytesReceived));
+                }
+            }
+        }
+
+        if (pimplOperation)
+        {
+            pimplOperation();
+        }
+    }
+    catch (...)
+    {
+        ctsConfig::PrintThrownException();
+    }
+
+    InitiateRecv();
+}
+} // namespace

--- a/ctsTraffic/ctsMediaUploadServerListeningSocket.h
+++ b/ctsTraffic/ctsMediaUploadServerListeningSocket.h
@@ -1,0 +1,56 @@
+/*
+Upload listening socket header
+*/
+#pragma once
+
+// cpp headers
+#include <array>
+#include <memory>
+// os headers
+#include <Windows.h>
+// ctl headers
+#include <ctSockaddr.hpp>
+#include <ctThreadIocp.hpp>
+// project headers
+#include "ctsConfig.h"
+
+namespace ctsTraffic
+{
+class ctsMediaUploadServerListeningSocket
+{
+private:
+    static constexpr size_t c_recvBufferSize = 1024;
+
+    std::shared_ptr<ctl::ctThreadIocp> m_threadIocp;
+
+    mutable wil::critical_section m_listeningSocketLock{ctsConfig::ctsConfigSettings::c_CriticalSectionSpinlock};
+    _Requires_lock_held_(m_listeningSocketLock) wil::unique_socket m_listeningSocket;
+
+    const ctl::ctSockaddr m_listeningAddr;
+    std::array<char, c_recvBufferSize> m_recvBuffer{};
+    DWORD m_recvFlags{};
+    ctl::ctSockaddr m_remoteAddr;
+    int m_remoteAddrLen{};
+    bool m_priorFailureWasConnectionReset = false;
+
+    void RecvCompletion(OVERLAPPED* pOverlapped) noexcept;
+
+public:
+    ctsMediaUploadServerListeningSocket(
+        wil::unique_socket&& listeningSocket,
+        ctl::ctSockaddr listeningAddr);
+
+    ~ctsMediaUploadServerListeningSocket() noexcept;
+
+    SOCKET GetSocket() const noexcept;
+
+    ctl::ctSockaddr GetListeningAddress() const noexcept;
+
+    void InitiateRecv() noexcept;
+
+    ctsMediaUploadServerListeningSocket(const ctsMediaUploadServerListeningSocket&) = delete;
+    ctsMediaUploadServerListeningSocket& operator=(const ctsMediaUploadServerListeningSocket&) = delete;
+    ctsMediaUploadServerListeningSocket(ctsMediaUploadServerListeningSocket&&) = delete;
+    ctsMediaUploadServerListeningSocket& operator=(ctsMediaUploadServerListeningSocket&&) = delete;
+};
+}

--- a/ctsTraffic/ctsTraffic.vcxproj
+++ b/ctsTraffic/ctsTraffic.vcxproj
@@ -414,6 +414,8 @@
     <ClCompile Include="ctsIOPattern.cpp" />
     <ClCompile Include="ctsIOPatternMediaStream.cpp" />
     <ClCompile Include="ctsMediaStreamClient.cpp" />
+    <ClCompile Include="ctsMediaUploadClient.cpp" />
+    <ClCompile Include="ctsMediaUploadServer.cpp" />
     <ClCompile Include="ctsMediaStreamServer.cpp" />
     <ClCompile Include="ctsReadWriteIocp.cpp" />
     <ClCompile Include="ctsRioIocp.cpp" />
@@ -426,6 +428,8 @@
     <ClCompile Include="ctsTraffic.cpp" />
     <ClCompile Include="ctsMediaStreamServerListeningSocket.cpp" />
     <ClCompile Include="ctsMediaStreamServerConnectedSocket.cpp" />
+    <ClCompile Include="ctsMediaUploadServerListeningSocket.cpp" />
+    <ClCompile Include="ctsMediaUploadServerConnectedSocket.cpp" />
     <ClCompile Include="ctsWinsockLayer.cpp" />
     <ClCompile Include="ctsWSASocket.cpp" />
   </ItemGroup>
@@ -475,6 +479,11 @@
     <ClInclude Include="ctsMediaStreamProtocol.hpp" />
     <ClInclude Include="ctsMediaStreamServer.h" />
     <ClInclude Include="ctsMediaStreamServerConnectedSocket.h" />
+    <ClInclude Include="ctsMediaUploadClient.h" />
+    <ClInclude Include="ctsMediaUploadServerListeningSocket.h" />
+    <ClInclude Include="ctsMediaUploadProtocol.hpp" />
+    <ClInclude Include="ctsMediaUploadServer.h" />
+    <ClInclude Include="ctsMediaUploadServerConnectedSocket.h" />
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>

--- a/ctsTraffic/ctsTraffic.vcxproj
+++ b/ctsTraffic/ctsTraffic.vcxproj
@@ -412,6 +412,7 @@
     <ClCompile Include="ctsConnectByName.cpp" />
     <ClCompile Include="ctsConnectEx.cpp" />
     <ClCompile Include="ctsIOPattern.cpp" />
+    <ClCompile Include="ctsIOPatternMediaUpload.cpp" />
     <ClCompile Include="ctsIOPatternMediaStream.cpp" />
     <ClCompile Include="ctsMediaStreamClient.cpp" />
     <ClCompile Include="ctsMediaUploadClient.cpp" />

--- a/ctsTraffic/ctsTraffic.vcxproj.filters
+++ b/ctsTraffic/ctsTraffic.vcxproj.filters
@@ -99,6 +99,21 @@
     <ClCompile Include="ctsConnectByName.cpp">
       <Filter>TCPFunctions</Filter>
     </ClCompile>
+    <ClCompile Include="ctsIOPatternMediaUpload.cpp">
+      <Filter>MediaStreaming</Filter>
+    </ClCompile>
+    <ClCompile Include="ctsMediaUploadClient.cpp">
+      <Filter>MediaStreaming</Filter>
+    </ClCompile>
+    <ClCompile Include="ctsMediaUploadServer.cpp">
+      <Filter>MediaStreaming</Filter>
+    </ClCompile>
+    <ClCompile Include="ctsMediaUploadServerConnectedSocket.cpp">
+      <Filter>MediaStreaming</Filter>
+    </ClCompile>
+    <ClCompile Include="ctsMediaUploadServerListeningSocket.cpp">
+      <Filter>MediaStreaming</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Resource.rc">
@@ -234,6 +249,20 @@
     </ClInclude>
     <ClInclude Include="..\ctl\ctThreadIocp_shard.hpp">
       <Filter>ctl</Filter>
+    <ClInclude Include="ctsMediaUploadClient.h">
+      <Filter>MediaStreaming</Filter>
+    </ClInclude>
+    <ClInclude Include="ctsMediaUploadProtocol.hpp">
+      <Filter>MediaStreaming</Filter>
+    </ClInclude>
+    <ClInclude Include="ctsMediaUploadServer.h">
+      <Filter>MediaStreaming</Filter>
+    </ClInclude>
+    <ClInclude Include="ctsMediaUploadServerConnectedSocket.h">
+      <Filter>MediaStreaming</Filter>
+    </ClInclude>
+    <ClInclude Include="ctsMediaUploadServerListeningSocket.h">
+      <Filter>MediaStreaming</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This pull request introduces a comprehensive suite of unit tests for the `ctsMediaUploadProtocol` helpers, covering client-side, server-side, server listening socket, and server connected socket behaviors. It also adds new Visual Studio project files to support building and running these tests.

Test coverage improvements:

* Added unit tests for client-side protocol helpers, including extraction of start messages and validation of error handling in `ctsMediaUploadClientUnitTest.cpp`.
* Added unit tests for server-side protocol helpers, verifying correct construction of connection ID tasks in `ctsMediaUploadServerUnitTest.cpp`.
* Added unit tests for server listening socket helpers, testing construction of start tasks and connection ID task length in `ctsMediaUploadServerListeningSocketUnitTest.cpp`.
* Added unit tests for server connected socket helpers, including buffer length validation for data and ID frames, along with necessary stubs for configuration dependencies in `ctsMediaUploadServerConnectedSocketUnitTest.cpp`.

Build system and project structure:

* Introduced new Visual Studio project files for each test suite, enabling compilation and execution of the added unit tests:  
  * `ctsMediaUploadClientUnitTest.vcxproj`  
  * `ctsMediaUploadServerUnitTest.vcxproj`  
  * `ctsMediaUploadServerListeningSocketUnitTest.vcxproj`  
  * `ctsMediaUploadServerConnectedSocketUnitTest.vcxproj`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media upload IO pattern support added for client and server roles in traffic testing scenarios.

* **Tests**
  * Comprehensive unit tests added for media upload protocol message handling and socket buffer validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->